### PR TITLE
Add language-aware fast OCR and vision chat mode

### DIFF
--- a/OCR/config.json
+++ b/OCR/config.json
@@ -4,7 +4,7 @@
   "ocr_model": "qwen/qwen2.5-vl-7b",
   "translate_model": "qwen/qwen3-8b",
   "fast_vlm_mode": false,
-  "fast_vlm_model": "",
+  "fast_vlm_model": "lfm2-vl-1.6b",
   "target_language": "Korean",
   "hotkey": "ctrl+alt+o",
   "copy_to_clipboard": true,

--- a/Overlay/config.yaml
+++ b/Overlay/config.yaml
@@ -14,6 +14,14 @@ llm_chat:     # 14B (기본 채팅)
   max_new_tokens: 8096
   temperature: 0.2
 
+llm_vision:   # 이미지가 포함된 대화용
+  endpoint: "http://127.0.0.1:1234/v1"
+  model: "gemma-3-12b-it-qat"
+  api_key: "lm-studio"
+  timeout_seconds: 60
+  max_new_tokens: 8096
+  temperature: 0.2
+
 llm_summary:  # 20B (정확 요약/검색; 환각 적게)
   endpoint: "http://127.0.0.1:1234/v1"
   model: "openai/gpt-oss-20b"


### PR DESCRIPTION
## Summary
- strip `<think>` blocks from LLM event text before display
- add fast OCR mode using lfm2-vl-1.6b and translate English via hyperclovax-seed-text-instruct-1.5b, Japanese/Chinese via qwen/qwen3-4b-thinking-2507
- route image-containing chats through gemma-3-12b-it-qat vision model

## Testing
- `python -m py_compile Overlay/overlay_app.py`
- `python -m py_compile OCR/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68abf3f6e4c483339dcfa3a56c0b339f