### PR TITLE
feat: add vision mode and fast OCR toggle

### DIFF
--- a/OCR/main.py
+++ b/OCR/main.py
@@ -308,6 +308,8 @@ class MainWindow(QMainWindow):
         self.chk_fast.setChecked(self.cfg.get("fast_vlm_mode", False))
         self.ed_fast_model = QLineEdit(self.cfg.get("fast_vlm_model", ""))
         self.ed_fast_model.setPlaceholderText("예: lfm2-vl-1.6b")
+        self.chk_fast.toggled.connect(self._on_fast_toggled)
+        self._on_fast_toggled(self.chk_fast.isChecked())
 
         # 알림/옵션
         self.chk_copy = QCheckBox("번역 결과를 자동으로 클립보드에 복사")
@@ -427,6 +429,11 @@ class MainWindow(QMainWindow):
         self.register_hotkey(auto=True)
         self.shortcut = QShortcut(QKeySequence(self.cfg["hotkey"]), self)
         self.shortcut.activated.connect(self.trigger_snip)
+
+    def _on_fast_toggled(self, checked: bool):
+        """고속 모드 토글 시 기본 OCR/번역 설정 비활성화"""
+        self.ed_ocr_model.setEnabled(not checked)
+        self.ed_trans_model.setEnabled(not checked)
 
     # ---------- 알림 유틸 ----------
     def _truncate(self, s: str, max_len: int = 240) -> str:

--- a/Overlay/overlay_app.py
+++ b/Overlay/overlay_app.py
@@ -20,6 +20,7 @@ import re
 import subprocess
 import platform
 import datetime
+import base64
 from typing import Dict, Any, List, Optional
 from dataclasses import dataclass, field
 
@@ -689,6 +690,8 @@ A: {"say": "안녕하세요! 무엇을 도와드릴까요?", "tool_calls": []}
         headers = {"Content-Type": "application/json", "Accept": "application/json"}
         if llm_cfg.get("api_key"):
             headers["Authorization"] = f"Bearer {llm_cfg['api_key']}"
+        if "20b" in llm_cfg.get("model", "").lower() and not any(m.get("role") == "system" for m in messages):
+            messages = [{"role": "system", "content": "Reasoning: medium"}] + messages
         payload = {"model": llm_cfg["model"], "messages": messages, "temperature": 0.2}
         timeout = httpx.Timeout(connect=5.0, read=float(llm_cfg.get("timeout_seconds", 60)), write=15.0, pool=10.0)
         url = f"{llm_cfg['endpoint'].rstrip('/')}/chat/completions"
@@ -1177,6 +1180,7 @@ class OverlayWindow(QtWidgets.QWidget):
         self.tray = tray
         self.mode = "tools"
         self.transcript = []
+        self.pending_image = None  # vision용 임시 이미지 저장
         
         # Pin 모델 관리
         self.pinned_model = None  # None, "4b", "14b", "20b"
@@ -1217,11 +1221,18 @@ class OverlayWindow(QtWidgets.QWidget):
         self.input.setStyleSheet("color:#E7F1FF; background: rgba(255,255,255,28); padding:6px 10px; border-radius:10px;")
         self.input.returnPressed.connect(self.on_send)
 
+        self.btn_image = QtWidgets.QPushButton("🖼️", self.container)
+        self.btn_image.setFixedWidth(40)
+        self.btn_image.clicked.connect(self.on_image)
+
         layout = QtWidgets.QVBoxLayout(self.container)
         layout.setContentsMargins(14, 14, 14, 14)
         layout.addWidget(self.title, 0)
         layout.addWidget(self.output, 1)
-        layout.addWidget(self.input, 0)
+        input_row = QtWidgets.QHBoxLayout()
+        input_row.addWidget(self.input, 1)
+        input_row.addWidget(self.btn_image, 0)
+        layout.addLayout(input_row, 0)
 
         self._drag_pos = None
         self.setWindowOpacity(float(ui["opacity"]))
@@ -1362,18 +1373,26 @@ class OverlayWindow(QtWidgets.QWidget):
 
     def _update_title(self):
         """제목 업데이트 (모드 및 pin 상태 반영)"""
-        mode_text = 'Chat(14B)' if self.mode == 'chat' else 'Tools(4B)'
-        
-        if self.pin_active and self.pinned_model:
-            pin_text = f" 📌{self.pinned_model.upper()}"
-            mode_text += pin_text
-            
-        self.title.setText(f"Luna Overlay v9 – Mode: {mode_text}")
+        if self.mode == 'chat':
+            mode_text = 'Chat(14B)'
+        elif self.mode == 'vision':
+            mode_text = 'Vision(12B)'
+        else:
+            mode_text = 'Tools(4B)'
+
+        pin_text = f" | Pin: {self.pinned_model.upper()}" if self.pin_active and self.pinned_model else ""
+        self.title.setText(f"Luna Overlay v9 – Mode: {mode_text}{pin_text}")
 
     def set_mode(self, mode: str):
         self.mode = mode
         self._update_title()
-        self._append("overlay", f"모드 전환: {'대화모드(14B)' if mode=='chat' else '툴 모드(4B)'}")
+        if mode == 'vision':
+            desc = '비전 모드(12B)'
+        elif mode == 'chat':
+            desc = '대화모드(14B)'
+        else:
+            desc = '툴 모드(4B)'
+        self._append("overlay", f"모드 전환: {desc}")
 
     def _get_effective_llm_config(self, preferred_type: str = "tools") -> Dict[str, Any]:
         """Pin 상태를 고려한 LLM 설정 반환"""
@@ -1424,15 +1443,23 @@ class OverlayWindow(QtWidgets.QWidget):
             m_tools = (cfg.get('llm_tools') or cfg.get('llm') or {}).get('model')
             m_chat = (cfg.get('llm_chat') or cfg.get('llm') or {}).get('model')
             pin_info = ""
-        
+        m_vision = (cfg.get('llm_vision') or cfg.get('llm_chat') or cfg.get('llm') or {}).get('model')
+
         px = cfg.get("proxy", {})
         purl = f"http://{px.get('host','127.0.0.1')}:{int(px.get('port',8350))}/v1/chat/completions"
-        
+
         # 이벤트 통계 추가
         stats = self.event_handler.get_stats()
-        
-        return (f"모드: {'대화(14B)' if self.mode=='chat' else '툴(4B)'}{pin_info} | "
-                f"tools={m_tools} | chat={m_chat} | proxy={purl}\n"
+
+        if self.mode == 'chat':
+            mode_disp = '대화(14B)'
+        elif self.mode == 'vision':
+            mode_disp = '비전(12B)'
+        else:
+            mode_disp = '툴(4B)'
+
+        return (f"모드: {mode_disp}{pin_info} | "
+                f"tools={m_tools} | chat={m_chat} | vision={m_vision} | proxy={purl}\n"
                 f"이벤트: 총 {stats['total_received']}개, 에러 {stats['errors']}개 "
                 f"({stats['error_rate']:.1%})")
 
@@ -1470,11 +1497,19 @@ class OverlayWindow(QtWidgets.QWidget):
                 self.appended.emit('error', f'tool calls failed: {e}')
         threading.Thread(target=_w, daemon=True).start()
 
+    def _remove_think_tags(self):
+        raw = self.output.toPlainText()
+        cleaned = re.sub(r"<think>.*?</think>", "", raw, flags=re.DOTALL | re.IGNORECASE)
+        cleaned = re.sub(r"</?think>", "", cleaned, flags=re.IGNORECASE)
+        self.output.setPlainText(cleaned)
+        self._append("overlay", "<Think> 태그 제거됨")
+
     def _help(self):
         self._append("overlay",
                      "명령어:\n"
                      "  /대화모드 | /chat        → 대화모드(14B)\n"
                      "  /대화종료 | /end         → 툴 모드(4B)\n"
+                     "  /vision                → 비전모드(12B)\n"
                      "  /상태 | /status          → 현재 모드/모델/프록시/이벤트 통계 표시\n"
                      "  /리셋 | /reset           → 히스토리 초기화 + tool_memory 재적용\n"
                      "  /memory reload           → tool_memory.txt 다시 읽기\n"
@@ -1498,6 +1533,7 @@ class OverlayWindow(QtWidgets.QWidget):
                      "  /event stt <url>       → STT 이벤트 URL 변경\n"
                      "  /20B                   → 대화모델을 GPT-OSS-20B로 설정\n"
                      "  /14B                   → 대화모델을 GPT-OSS-14B로 설정\n"
+                     "  /clearthink            → 출력의 <Think> 태그 제거\n"
                      )
 
     def _try_slash(self, text: str) -> bool:
@@ -1511,6 +1547,8 @@ class OverlayWindow(QtWidgets.QWidget):
             self.set_mode("chat"); return True
         if cmd in ("/대화종료", "/end"):
             self.set_mode("tools"); return True
+        if cmd == "/vision":
+            self.set_mode("vision"); return True
         if cmd in ("/상태", "/status"):
             self._append("overlay", self._status_line()); return True
         if cmd == "/stats":
@@ -1578,6 +1616,8 @@ class OverlayWindow(QtWidgets.QWidget):
                 open(path, "w", encoding="utf-8").write("\n".join(self.transcript)); self._append("overlay", f"저장됨: {path}")
             except Exception as e: self._append("error", f"저장 실패: {e}")
             return True
+        if cmd == "/clearthink":
+            self._remove_think_tags(); return True
         if cmd == "/ocr" and len(toks) == 2 and toks[1].lower() in ("on","off"):
             name = 'ocr.start' if toks[1].lower()=='on' else 'ocr.stop'
             self._run_tool_calls_async([{"name": name, "args": {}}])
@@ -1617,10 +1657,13 @@ class OverlayWindow(QtWidgets.QWidget):
     @QtCore.pyqtSlot()
     def on_send(self):
         text = self.input.text().strip()
-        if not text: return
+        if not text and not self.pending_image:
+            return
         self.input.clear()
-        if self._try_slash(text): return
-        self._append("you", text)
+        if text and self._try_slash(text):
+            return
+        if text:
+            self._append("you", text)
 
         def worker(msg=text, mode=self.mode):
             try:
@@ -1646,6 +1689,21 @@ class OverlayWindow(QtWidgets.QWidget):
                         raw = self.orch.last_tools_raw
                         if len(raw) > 4000: raw = raw[:4000] + " ... (truncated)"
                         self.appended.emit("debug", f"raw: {raw}")
+                elif mode == "vision":
+                    img = self.pending_image
+                    self.pending_image = None
+                    content: List[Dict[str, Any]] = []
+                    if img:
+                        content.append(img)
+                    if msg:
+                        content.append({"type": "text", "text": msg})
+                    messages = [{"role": "user", "content": content}]
+                    self.appended.emit("overlay", "↗ LLM(vision) 요청")
+                    out = self.orch.chat_vision(messages)
+                    out = strip_think_and_fences(out)
+                    dt = int((time.time()-t0)*1000)
+                    self.appended.emit("overlay", f"↙ LLM(vision) 응답 ({dt}ms)")
+                    self.appended.emit("vision", out or "(empty)")
                 else:
                     self.appended.emit("overlay", "↗ LLM(tools) 요청")
                     parsed = self.orch.orchestrate(msg)
@@ -1664,6 +1722,26 @@ class OverlayWindow(QtWidgets.QWidget):
                 self.appended.emit("error", str(e))
                 logger.exception("overlay worker error")
         threading.Thread(target=worker, daemon=True).start()
+
+    def on_image(self):
+        """이미지를 선택해 다음 프롬프트에 첨부"""
+        path, _ = QtWidgets.QFileDialog.getOpenFileName(self, "Select Image", "", "Images (*.png *.jpg *.jpeg *.bmp)")
+        if not path:
+            return
+        try:
+            with open(path, "rb") as f:
+                b64 = base64.b64encode(f.read()).decode("ascii")
+            mime = "image/png"
+            if path.lower().endswith(".jpg") or path.lower().endswith(".jpeg"):
+                mime = "image/jpeg"
+            elif path.lower().endswith(".bmp"):
+                mime = "image/bmp"
+
+            self.pending_image = {"type": "image_url", "image_url": {"url": f"data:{mime};base64,{b64}"}}
+            self.set_mode("vision")
+            self._append("you", f"[이미지 추가] {os.path.basename(path)}")
+        except Exception as e:
+            self._append("error", f"이미지 로드 실패: {e}")
 
 # ---------------- Tray ----------------
 


### PR DESCRIPTION
## Summary
- disable standard OCR/translation inputs when fast mode is enabled
- add vision mode with image upload button and gemma-3-12b-it-qat support
- allow removing <Think> tags and switching modes via new slash commands
- queue vision images so prompts can be sent with them and keep model until pin change
- prepend a medium reasoning system message when 20B model is used

## Testing
- `python -m py_compile OCR/main.py Overlay/overlay_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68abfdcde7d48333bbd14c2beda9f479