### PR TITLE
Enable per-app audio capture

### DIFF
--- a/STT/README.md
+++ b/STT/README.md
@@ -17,7 +17,7 @@ python app.py                  # 기본: 자동 루프백 캡처 + 로컬 STT + 
 ## 핵심 설정 (`config.yaml`)
 - `capture.mode`: `"auto"`(기본) → WASAPI (loopback) 시도, 실패 시 `soundcard`로 기본 스피커 루프백
 - `capture.mode: "device"` + `device_index`로 **특정 장치 고정**
-- `capture.mode: "app"` + `apps` 배열로 **특정 프로그램 세션만 캡처** (예: `Discord.exe`, `chrome.exe`)
+- `capture.mode: "app"` + `apps` 배열로 **특정 프로그램 세션만 캡처** (예: `Discord.exe`, `msedge.exe`, `firefox.exe`, `chrome.exe`)
 - `stt.backend`: `"local"`(faster-whisper) 또는 `"server"`(내가 제공한 `stt_server.py` 같은 서버)
 - `force.enable: true` → **VAD가 말을 못 잡아도 RMS 기준으로 강제 STT**
 

--- a/STT/config.yaml
+++ b/STT/config.yaml
@@ -4,10 +4,11 @@
 
 # ---- Capture ----
 capture:
-  mode: "auto"                # "auto" | "device" | "app"
+  mode: "app"                # "auto" | "device" | "app"
   device_index: 56            # used only if mode="device"
   device_name: ""             # optional substring match, used only if mode="device"
-  apps: []                    # list of process names when mode="app" (e.g., ["Discord.exe", "chrome.exe"])
+  apps: ["Discord.exe", "msedge.exe", "firefox.exe", "chrome.exe"]
+                            # list of process names when mode="app" (e.g., ["Discord.exe", "msedge.exe"])
   sample_rate: 16000          # internal processing sample rate (VAD/STT)
   block_ms: 20                # frame size in milliseconds (10/20/30ms typical for VAD)
   channels: 1                 # mono


### PR DESCRIPTION
## Summary
- default to per-application loopback audio capture
- document example app names like Discord, Edge, Firefox, and Chrome

## Testing
- `python -m py_compile STT/VSRG-Ts-to-kr.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac08932a7c83339e941472a1f9da0b