### PR TITLE
Add vision model switch and STT model display with URL opener plugin

### DIFF
--- a/Overlay/overlay_app.py
+++ b/Overlay/overlay_app.py
@@ -143,7 +143,12 @@ class EventHandler:
         language = payload.get("language", "")
         if language:
             display_text += f" [{language}]"
-        
+
+        # 사용된 STT 모델 정보
+        model = payload.get("model", "")
+        if model:
+            display_text += f" ({model})"
+
         self._emit_safe("🎤 STT", display_text)
         return True
     
@@ -1525,6 +1530,7 @@ class OverlayWindow(QtWidgets.QWidget):
                      "  /memory reload           → tool_memory.txt 다시 읽기\n"
                      "  /model tools <name>      → 4B 모델 변경\n"
                      "  /model chat <name>       → 14B 모델 변경\n"
+                     "  /model vision <name>     → 비전 모델 변경\n"
                      "  /opacity <0~1>           → 투명도 조절\n"
                      "  /size WxH                → 크기 변경 ex) /size 680x520\n"
                      "  /pos X Y                 → 위치 이동\n"
@@ -1602,6 +1608,8 @@ class OverlayWindow(QtWidgets.QWidget):
                 self.orch.cfg.setdefault("llm_tools", {})["model"] = name; self._append("overlay", f"tools 모델 변경: {name}"); return True
             if which == "chat":
                 self.orch.cfg.setdefault("llm_chat", {})["model"] = name; self._append("overlay", f"chat 모델 변경: {name}"); return True
+            if which == "vision":
+                self.orch.cfg.setdefault("llm_vision", {})["model"] = name; self._append("overlay", f"vision 모델 변경: {name}"); return True
         if cmd == "/opacity" and len(toks) == 2:
             try:
                 val = float(toks[1]); self.setWindowOpacity(max(0.1, min(1.0, val))); self._append("overlay", f"opacity={self.windowOpacity():.2f}"); return True

--- a/Overlay/plugins/open_url.py
+++ b/Overlay/plugins/open_url.py
@@ -1,0 +1,17 @@
+"""Plugin to open URLs in the default web browser."""
+import webbrowser
+
+
+def register(registry):
+    def open_url(payload):
+        url = (payload or {}).get("url") or (payload or {}).get("href")
+        if not url:
+            return {"ok": False, "error": "missing url"}
+        try:
+            webbrowser.open(url)
+            registry.emit("web", f"OPEN: {url}")
+            return {"ok": True, "url": url}
+        except Exception as e:
+            return {"ok": False, "error": str(e)}
+
+    registry.register_tool("web.open", open_url)

--- a/Overlay/tool_memory.txt
+++ b/Overlay/tool_memory.txt
@@ -6,6 +6,7 @@ Hard rules:
 - Prefer short, actionable outputs. If you have nothing to say, omit "say".
 - Never translate content yourself. External pipelines handle translation.
 - Do not store memory; assume these rules persist between turns.
+- Tool calls work only when response is valid JSON; other text is ignored.
 
 When to call tools:
 1) OCR needed (new subtitles, small UI text, non-Korean text visible)

--- a/STT/VSRG-Ts-to-kr.py
+++ b/STT/VSRG-Ts-to-kr.py
@@ -994,6 +994,7 @@ def run_pipeline(cfg: Config):
                             "text": english,
                             "translation": korean,
                             "source": "VSRG",
+                            "model": cfg.stt.model,
                         })
                     continue
 
@@ -1032,6 +1033,7 @@ def run_pipeline(cfg: Config):
                                     "text": english,
                                     "translation": korean,
                                     "source": "VSRG/forced",
+                                    "model": cfg.stt.model,
                                 })
                             continue
                         force_ms = 0
@@ -1062,6 +1064,7 @@ def run_pipeline(cfg: Config):
                                 "text": english,
                                 "translation": korean,
                                 "source": "VSRG/sustained",
+                                "model": cfg.stt.model,
                             })
         except KeyboardInterrupt:
             print("[INFO] Interrupted.")


### PR DESCRIPTION
## Summary
- Allow changing vision model via `/model vision <name>`
- Show STT transcription model and embed model info in STT events
- Add simple plugin to open URLs and clarify JSON-only tool invocation in tool memory

## Testing
- `python -m py_compile Overlay/overlay_app.py Overlay/plugins/open_url.py STT/VSRG-Ts-to-kr.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac09fdb88c83339460ee19a83ca62b