### PR TITLE
feat: add open url tool and discord endpoints

### DIFF
--- a/Overlay/tool_memory.txt
+++ b/Overlay/tool_memory.txt
@@ -23,3 +23,6 @@ When to call tools:
 
 4) Leave a note/event for the Agent (no UI output)
    -> {"name":"agent.event","args":{"type":"overlay.note","payload":{"note":"...","source":"overlay"},"priority":5}}
+
+5) Open a link in the default browser
+   -> {"name":"overlay.open_url","args":{"url":"https://..."}}


### PR DESCRIPTION
## Summary
- extend default tool memory with JSON-only rule, Discord summarization, and link opener
- add endpoints for `discord.collect.start/stop`
- handle `overlay.open_url` tool directly in overlay app

## Testing
- `python -m py_compile Overlay/overlay_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac11af704c8333985bf0d950f4ace1