### PR TITLE
fix: ensure overlay app finds tools module

### DIFF
--- a/Overlay/overlay_app.py
+++ b/Overlay/overlay_app.py
@@ -24,6 +24,7 @@ import base64
 import webbrowser
 from typing import Dict, Any, List, Optional
 from dataclasses import dataclass, field
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from tools.security.orchestrator_hooks import (
     pre_ingest_external,
     before_tool,


### PR DESCRIPTION
## Summary
- add repository root to `sys.path` in `overlay_app.py` so the `tools` package can be imported when running the script directly

## Testing
- `python -m py_compile Overlay/overlay_app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac192ff54883339319ea88750e7418