### PR TITLE
feat: integrate YAML tools into overlay plugin system

### DIFF
--- a/Overlay/__init__.py
+++ b/Overlay/__init__.py
@@ -1,0 +1,1 @@
+"""Overlay package"""

--- a/Overlay/overlay_plugin_system.py
+++ b/Overlay/overlay_plugin_system.py
@@ -16,6 +16,12 @@ from abc import ABC, abstractmethod
 from typing import Dict, Any, List, Optional, Callable
 from pathlib import Path
 
+# 외부 tools 폴더에서 YAML 기반 플러그인을 가져온다
+try:
+    from tools.overlay_plugin import YamlToolsPlugin
+except Exception:
+    YamlToolsPlugin = None
+
 # 로깅 설정
 try:
     from loguru import logger
@@ -426,12 +432,15 @@ class PluginManager:
     
     def _register_default_plugins(self):
         """기본 플러그인들 등록"""
-        default_plugins = [
+        default_plugins = []
+        if YamlToolsPlugin:
+            default_plugins.append(YamlToolsPlugin)
+        default_plugins.extend([
             SecurityPlugin,
             SchedulePlugin,
             WebPlugin,
             KnowledgePlugin,
-        ]
+        ])
         
         for plugin_cls in default_plugins:
             try:

--- a/tools/overlay_plugin.py
+++ b/tools/overlay_plugin.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+from typing import Dict, Any, Callable, List
+from pathlib import Path
+
+from .tool.runtime_registry import ToolRegistry
+
+
+class YamlToolsPlugin:
+    """Expose YAML-defined tools from tools/config/tools.yaml as overlay plugin."""
+
+    def __init__(self, config: Dict[str, Any] | None = None) -> None:
+        self.config = config or {}
+        self.name = self.__class__.__name__
+        self.enabled = True
+        self.handlers: Dict[str, Callable[[Dict[str, Any]], Any]] = {}
+        self._setup()
+
+    def _setup(self) -> None:
+        cfg_path = Path(__file__).resolve().parent / "config" / "tools.yaml"
+        self.registry = ToolRegistry.from_yaml(str(cfg_path))
+        for name in self.registry.schemas.keys():
+            self.handlers[name] = self._make_handler(name)
+
+    def _make_handler(self, name: str) -> Callable[[Dict[str, Any]], Any]:
+        def _handler(args: Dict[str, Any]) -> Any:
+            return self.registry.execute(name, args)
+        return _handler
+
+    def get_handlers(self) -> Dict[str, Callable[[Dict[str, Any]], Any]]:
+        return self.handlers
+
+    def get_tools_schema(self) -> List[Dict[str, Any]]:
+        return self.registry.tools_array()
+
+    def on_event(self, event_type: str, payload: Dict[str, Any]) -> bool:
+        return False
+
+    def cleanup(self) -> None:
+        pass
+


### PR DESCRIPTION
## Summary
- add `YamlToolsPlugin` to expose tools from `tools/config/tools.yaml`
- load the YAML-backed plugin in `PluginManager`
- make `Overlay` a package for import

## Testing
- `pytest -q`
- `ruff check .` *(fails: Multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ac393b3ef48333b1d5ca918f9c51e8