### PR TITLE
fix: prevent STT event duplication

### DIFF
--- a/agent/plugins/stt_plugin.py
+++ b/agent/plugins/stt_plugin.py
@@ -15,5 +15,8 @@ class STTPlugin(BasePlugin):
                 dedup.append(p)
         cleaned = " ".join(dedup)
         event.payload["text"] = cleaned
-        await self.ctx.bus.publish(event)  # translator에게 전달
-        logger.debug(f"[{self.name}] cleaned and republished stt.text")
+        # The event bus delivers this event to all subscribers in order,
+        # so republishing would cause duplicate processing. Simply update
+        # the payload and allow downstream handlers (e.g. translator) to
+        # see the cleaned text.
+        logger.debug(f"[{self.name}] cleaned stt.text")

--- a/tests/test_stt_plugin.py
+++ b/tests/test_stt_plugin.py
@@ -1,0 +1,37 @@
+import asyncio
+from types import SimpleNamespace
+from agent.event_bus import EventBus
+from agent.plugins.stt_plugin import STTPlugin
+from agent.schemas import Event
+
+
+def test_stt_plugin_does_not_republish():
+    async def runner():
+        ctx = SimpleNamespace()
+        ctx.bus = EventBus()
+        stt = STTPlugin(ctx)
+
+        calls = []
+
+        async def dummy_translator(ev):
+            calls.append(ev.payload.get("text"))
+
+        ctx.bus.subscribe("stt.text", stt.handle)
+        ctx.bus.subscribe("stt.text", dummy_translator)
+
+        ev = Event(type="stt.text", payload={"text": "hi hi"}, priority=5)
+        await ctx.bus.publish(ev)
+
+        async def dispatch_once(bus):
+            _, _, e = await bus.queue.get()
+            for prefix, handlers in bus.subscribers.items():
+                if e.type.startswith(prefix):
+                    for h in handlers:
+                        await h(e)
+
+        while not ctx.bus.queue.empty():
+            await dispatch_once(ctx.bus)
+
+        assert calls == ["hi"]
+
+    asyncio.run(runner())


### PR DESCRIPTION
## Summary
- avoid republishing STT events to prevent duplicate downstream processing
- add regression test ensuring STT plugin emits cleaned text once

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad006d5d308333bddc17b3e7c38789