### PR TITLE
Fix overlay STT plugin and script path

### DIFF
--- a/Overlay/Overlay/config.yaml
+++ b/Overlay/Overlay/config.yaml
@@ -85,15 +85,15 @@ tools:
     method: "terminate"
 
   # STT start/stop
-  stt.start:
-    kind: "process"
-    id: "stt"
-    command: "D:/jip/home-agent/.venv/Scripts/python.exe"
-    args: ["D:/jip/home-agent/STT/VSRG-Ts-to-KR.py"]
-    cwd: "D:/jip/home-agent/STT"
-    no_console: true
-    env:
-      AGENT_EVENT_URL: "http://127.0.0.1:8350/event"
+    stt.start:
+      kind: "process"
+      id: "stt"
+      command: "D:/jip/home-agent/.venv/Scripts/python.exe"
+      args: ["D:/jip/home-agent/STT/VSRG-Ts-to-kr.py"]
+      cwd: "D:/jip/home-agent/STT"
+      no_console: true
+      env:
+        AGENT_EVENT_URL: "http://127.0.0.1:8350/event"
   stt.stop:
     kind: "process_stop"
     id: "stt"

--- a/Overlay/agent/plugins/stt_plugin.py
+++ b/Overlay/agent/plugins/stt_plugin.py
@@ -15,5 +15,8 @@ class STTPlugin(BasePlugin):
                 dedup.append(p)
         cleaned = " ".join(dedup)
         event.payload["text"] = cleaned
-        await self.ctx.bus.publish(event)  # translator에게 전달
-        logger.debug(f"[{self.name}] cleaned and republished stt.text")
+        # The event bus already delivers this event to downstream handlers
+        # in order. Republishing here would cause duplicate processing or
+        # even infinite loops. Simply update the payload so subsequent
+        # subscribers (e.g. translator) see the cleaned text.
+        logger.debug(f"[{self.name}] cleaned stt.text")

--- a/Overlay/config.yaml
+++ b/Overlay/config.yaml
@@ -85,15 +85,15 @@ tools:
     method: "terminate"
 
   # STT start/stop
-  stt.start:
-    kind: "process"
-    id: "stt"
-    command: "D:/jip/home-agent/.venv/Scripts/python.exe"
-    args: ["D:/jip/home-agent/STT/VSRG-Ts-to-KR.py"]
-    cwd: "D:/jip/home-agent/STT"
-    no_console: true
-    env:
-      AGENT_EVENT_URL: "http://127.0.0.1:8350/event"
+    stt.start:
+      kind: "process"
+      id: "stt"
+      command: "D:/jip/home-agent/.venv/Scripts/python.exe"
+      args: ["D:/jip/home-agent/STT/VSRG-Ts-to-kr.py"]
+      cwd: "D:/jip/home-agent/STT"
+      no_console: true
+      env:
+        AGENT_EVENT_URL: "http://127.0.0.1:8350/event"
   stt.stop:
     kind: "process_stop"
     id: "stt"


### PR DESCRIPTION
## Summary
- prevent infinite event loops by removing republish in overlay STT plugin
- correct STT script path so overlay can launch speech-to-text properly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad076ca3948333be560990eef3d91c