### PR TITLE
Fix STT plugin event URL

### DIFF
--- a/Overlay/Overlay/config.yaml
+++ b/Overlay/Overlay/config.yaml
@@ -78,7 +78,7 @@ tools:
     cwd: "D:/jip/home-agent/OCR"
     no_console: true
     env:
-      AGENT_EVENT_URL: "http://127.0.0.1:8350/event"
+      AGENT_EVENT_URL: "http://127.0.0.1:8350/plugin/event"
   ocr.stop:
     kind: "process_stop"
     id: "ocr"
@@ -93,7 +93,7 @@ tools:
       cwd: "D:/jip/home-agent/STT"
       no_console: true
       env:
-        AGENT_EVENT_URL: "http://127.0.0.1:8350/event"
+        AGENT_EVENT_URL: "http://127.0.0.1:8350/plugin/event"
   stt.stop:
     kind: "process_stop"
     id: "stt"

--- a/Overlay/config.yaml
+++ b/Overlay/config.yaml
@@ -78,7 +78,7 @@ tools:
     cwd: "D:/jip/home-agent/OCR"
     no_console: true
     env:
-      AGENT_EVENT_URL: "http://127.0.0.1:8350/event"
+      AGENT_EVENT_URL: "http://127.0.0.1:8350/plugin/event"
   ocr.stop:
     kind: "process_stop"
     id: "ocr"
@@ -93,7 +93,7 @@ tools:
       cwd: "D:/jip/home-agent/STT"
       no_console: true
       env:
-        AGENT_EVENT_URL: "http://127.0.0.1:8350/event"
+        AGENT_EVENT_URL: "http://127.0.0.1:8350/plugin/event"
   stt.stop:
     kind: "process_stop"
     id: "stt"


### PR DESCRIPTION
## Summary
- Route OCR and STT tools to `/plugin/event` so STT no longer triggers 422 errors

## Testing
- `pip install -r requirements.txt || true`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad08e4dd5c8333b325f758e09bbbdf