### PR TITLE
feat: forward OCR & STT outputs to overlay

### DIFF
--- a/OCR/main.py
+++ b/OCR/main.py
@@ -544,11 +544,20 @@ class MainWindow(QMainWindow):
         # 결과 창/작은 팝업/중간 OCR 팝업은 전부 생략 — 토스트 + 복붙만!
         if self.cfg.get("copy_to_clipboard", True):
             QApplication.clipboard().setText((translated or ocr_text or "").strip())
-            _post_event("ocr.text", {
-            "text": translated or ocr_text,
-            "ocr": ocr_text,
-            "source": "HomeOCR",
-        })
+
+        model_info = {
+            "ocr_model": self.cfg.get("fast_vlm_model") if self.cfg.get("fast_vlm_mode", False) else self.cfg.get("ocr_model"),
+            "translate_model": self.cfg.get("translate_model"),
+        }
+        _post_event(
+            "ocr.text",
+            {
+                "text": translated or ocr_text,
+                "ocr": ocr_text,
+                "source": "HomeOCR",
+                **model_info,
+            },
+        )
 
         if self.cfg.get("notify_on_finish", True):
             self._show_windows_notification(

--- a/Overlay/OCR/main.py
+++ b/Overlay/OCR/main.py
@@ -537,11 +537,20 @@ class MainWindow(QMainWindow):
         # 결과 창/작은 팝업/중간 OCR 팝업은 전부 생략 — 토스트 + 복붙만!
         if self.cfg.get("copy_to_clipboard", True):
             QApplication.clipboard().setText((translated or ocr_text or "").strip())
-            _post_event("ocr.text", {
-            "text": translated or ocr_text,
-            "ocr": ocr_text,
-            "source": "HomeOCR",
-        })
+
+        model_info = {
+            "ocr_model": self.cfg.get("fast_vlm_model") if self.cfg.get("fast_vlm_mode", False) else self.cfg.get("ocr_model"),
+            "translate_model": self.cfg.get("translate_model"),
+        }
+        _post_event(
+            "ocr.text",
+            {
+                "text": translated or ocr_text,
+                "ocr": ocr_text,
+                "source": "HomeOCR",
+                **model_info,
+            },
+        )
 
         if self.cfg.get("notify_on_finish", True):
             self._show_windows_notification(

--- a/STT/VSRG-Ts-to-kr - 복사본.py
+++ b/STT/VSRG-Ts-to-kr - 복사본.py
@@ -864,12 +864,18 @@ def run_pipeline(cfg: Config):
                     if cfg.debug.write_wav_segments and english:
                         fname = os.path.join(seg_dir, f"{ts.replace(':','-')}_{dur_ms}ms.wav")
                         write_wav(fname, segment, cfg.capture.sample_rate)
-                        ui.push(english, korean)
-                        _post_event("stt.text", {
-                        "text": english,
-                        "translation": korean,
-                        "source": "VSRG",
-                        })
+                    ui.push(english, korean)
+                    if english:
+                        _post_event(
+                            "stt.text",
+                            {
+                                "text": english,
+                                "translation": korean,
+                                "source": "VSRG",
+                                "stt_model": cfg.stt.model,
+                                "translate_model": cfg.translate.model,
+                            },
+                        )
                     continue
 
                 # --- Forced segmentation bookkeeping (when VAD misses)
@@ -901,12 +907,18 @@ def run_pipeline(cfg: Config):
                             if cfg.debug.write_wav_segments and english:
                                 fname = os.path.join(seg_dir, f"{ts.replace(':','-')}_forced.wav")
                                 write_wav(fname, segment, cfg.capture.sample_rate)
-                                ui.push(english, korean)
-                                _post_event("stt.text", {
-                                "text": english,
-                                "translation": korean,
-                                "source": "VSRG/forced",
-                                 })
+                            ui.push(english, korean)
+                            if english:
+                                _post_event(
+                                    "stt.text",
+                                    {
+                                        "text": english,
+                                        "translation": korean,
+                                        "source": "VSRG/forced",
+                                        "stt_model": cfg.stt.model,
+                                        "translate_model": cfg.translate.model,
+                                    },
+                                )
                             continue
                         force_ms = 0
 
@@ -931,6 +943,17 @@ def run_pipeline(cfg: Config):
                             fname = os.path.join(seg_dir, f"{ts.replace(':','-')}_sustained.wav")
                             write_wav(fname, segment, cfg.capture.sample_rate)
                         ui.push(english, korean)
+                        if english:
+                            _post_event(
+                                "stt.text",
+                                {
+                                    "text": english,
+                                    "translation": korean,
+                                    "source": "VSRG/sustained",
+                                    "stt_model": cfg.stt.model,
+                                    "translate_model": cfg.translate.model,
+                                },
+                            )
 
         except KeyboardInterrupt:
             print("[INFO] Interrupted.")

--- a/STT/VSRG-Ts-to-kr.py
+++ b/STT/VSRG-Ts-to-kr.py
@@ -1012,12 +1012,16 @@ def run_pipeline(cfg: Config):
                         write_wav(fname, segment, cfg.capture.sample_rate)
                     ui.push(english, korean, speaker_id)
                     if english:
-                        _post_event("stt.text", {
-                            "text": english,
-                            "translation": korean,
-                            "source": "VSRG",
-                            "model": cfg.stt.model,
-                        })
+                        _post_event(
+                            "stt.text",
+                            {
+                                "text": english,
+                                "translation": korean,
+                                "source": "VSRG",
+                                "stt_model": cfg.stt.model,
+                                "translate_model": cfg.translate.model,
+                            },
+                        )
                     continue
 
                 # --- Forced segmentation bookkeeping (when VAD misses)
@@ -1052,12 +1056,16 @@ def run_pipeline(cfg: Config):
                                 write_wav(fname, segment, cfg.capture.sample_rate)
                             ui.push(english, korean, speaker_id)
                             if english:
-                                _post_event("stt.text", {
-                                    "text": english,
-                                    "translation": korean,
-                                    "source": "VSRG/forced",
-                                    "model": cfg.stt.model,
-                                })
+                                _post_event(
+                                    "stt.text",
+                                    {
+                                        "text": english,
+                                        "translation": korean,
+                                        "source": "VSRG/forced",
+                                        "stt_model": cfg.stt.model,
+                                        "translate_model": cfg.translate.model,
+                                    },
+                                )
                             continue
                         force_ms = 0
 
@@ -1084,12 +1092,16 @@ def run_pipeline(cfg: Config):
                             write_wav(fname, segment, cfg.capture.sample_rate)
                         ui.push(english, korean, speaker_id)
                         if english:
-                            _post_event("stt.text", {
-                                "text": english,
-                                "translation": korean,
-                                "source": "VSRG/sustained",
-                                "model": cfg.stt.model,
-                            })
+                            _post_event(
+                                "stt.text",
+                                {
+                                    "text": english,
+                                    "translation": korean,
+                                    "source": "VSRG/sustained",
+                                    "stt_model": cfg.stt.model,
+                                    "translate_model": cfg.translate.model,
+                                },
+                            )
         except KeyboardInterrupt:
             print("[INFO] Interrupted.")
         finally:


### PR DESCRIPTION
## Summary
- Always send OCR results to overlay regardless of clipboard setting
- Include model metadata for OCR, translation, and STT events

## Testing
- ⚠️ `pip install -r requirements.txt` (failed: Could not find a version that satisfies the requirement fastapi>=0.111.1)
- ✅ `pytest -q`
- ⚠️ `ruff check .` (reported numerous style issues)


------
https://chatgpt.com/codex/tasks/task_e_68ad595eebec8333ba4fff544d1ba568