### PR TITLE
Send toast notifications to overlay

### DIFF
--- a/OCR/main.py
+++ b/OCR/main.py
@@ -456,6 +456,8 @@ class MainWindow(QMainWindow):
         return self._truncate(translated or ocr_text)
 
     def _show_windows_notification(self, title: str, message: str):
+        # Lunar Bridge → Overlay toast
+        _post_event("overlay.toast", {"title": title, "text": message})
         if getattr(self, "tray", None):
             try:
                 self.tray.showMessage(title, message, QSystemTrayIcon.Information, 8000)

--- a/Overlay/OCR/main.py
+++ b/Overlay/OCR/main.py
@@ -449,6 +449,8 @@ class MainWindow(QMainWindow):
         return self._truncate(translated or ocr_text)
 
     def _show_windows_notification(self, title: str, message: str):
+        # Lunar Bridge → Overlay toast
+        _post_event("overlay.toast", {"title": title, "text": message})
         if getattr(self, "tray", None):
             try:
                 self.tray.showMessage(title, message, QSystemTrayIcon.Information, 8000)

--- a/STT/VSRG-Ts-to-kr.py
+++ b/STT/VSRG-Ts-to-kr.py
@@ -60,6 +60,18 @@ def _post_event(_type, _payload, _prio=5):
         )
     except Exception:
         pass
+    
+
+def _overlay_toast(message: str, title: str = "STT") -> None:
+    """Mirror STT results to Lunar Bridge overlay as toast messages."""
+    message = (message or "").strip()
+    if not message:
+        return
+    if len(message) > 240:
+        message = message[:239] + "…"
+    _post_event("overlay.toast", {"title": title, "text": message})
+
+
 def _log(s: str):
     print(f"[DEBUG] {s}")
 # Optional GUI
@@ -1022,6 +1034,7 @@ def run_pipeline(cfg: Config):
                                 "translate_model": cfg.translate.model,
                             },
                         )
+                        _overlay_toast(korean or english)
                     continue
 
                 # --- Forced segmentation bookkeeping (when VAD misses)
@@ -1066,6 +1079,7 @@ def run_pipeline(cfg: Config):
                                         "translate_model": cfg.translate.model,
                                     },
                                 )
+                                _overlay_toast(korean or english)
                             continue
                         force_ms = 0
 
@@ -1102,6 +1116,7 @@ def run_pipeline(cfg: Config):
                                     "translate_model": cfg.translate.model,
                                 },
                             )
+                            _overlay_toast(korean or english)
         except KeyboardInterrupt:
             print("[INFO] Interrupted.")
         finally:


### PR DESCRIPTION
## Summary
- Notify Lunar Bridge overlay whenever OCR or STT shows a toast
- Mirror OCR and STT events to the overlay via `overlay.toast`

## Testing
- `python -m pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi>=0.111.1)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad5cb096a48333a469aff514576d80