### PR TITLE
feat: show tools when requested

### DIFF
--- a/Overlay/overlay_app.py
+++ b/Overlay/overlay_app.py
@@ -965,6 +965,18 @@ A: {"say": "안녕하세요! 무엇을 도와드릴까요?", "tool_calls": []}
 
             before_tool(name, args)
 
+            if name == "agent.list_tools":
+                try:
+                    if self.window and hasattr(self.window, "_show_tools"):
+                        self.window._show_tools()
+                    else:
+                        handler = self.tool_handlers.get(name)
+                        if handler:
+                            handler(args)
+                except Exception as e:
+                    logger.error(f"[tool] agent.list_tools failed: {e}")
+                continue
+
             if name == "overlay.open_url":
                 url = args.get("url") or args.get("href")
                 if url:


### PR DESCRIPTION
## Summary
- display available tools when `agent.list_tools` tool call is emitted

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi>=0.111.1)*
- `pytest -q`
- `ruff check Overlay/overlay_app.py` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6f018e988333946aa2500223d4e9