### PR TITLE
feat: add GUI settings for relative paths

### DIFF
--- a/Gui_settings.py
+++ b/Gui_settings.py
@@ -1,0 +1,104 @@
+import os
+import json
+import yaml
+import tkinter as tk
+from tkinter import filedialog, messagebox
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+AGENT_CFG_PATH = os.path.join(BASE_DIR, "agent", "config.yaml")
+OVERLAY_CFG_PATH = os.path.join(BASE_DIR, "Overlay", "config.yaml")
+
+DEFAULTS = {
+    "python": os.path.join(".venv", "Scripts", "python.exe"),
+    "overlay_script": os.path.join("Overlay", "overlay_app.py"),
+    "ocr_script": os.path.join("OCR", "main.py"),
+    "stt_script": os.path.join("STT", "VSRG-Ts-to-kr.py"),
+}
+
+class SettingsGUI(tk.Tk):
+    def __init__(self):
+        super().__init__()
+        self.title("Home-Agent Settings")
+        self.resizable(False, False)
+        self.entries = {}
+        row = 0
+        for key, default in [
+            ("python", DEFAULTS["python"]),
+            ("overlay_script", DEFAULTS["overlay_script"]),
+            ("ocr_script", DEFAULTS["ocr_script"]),
+            ("stt_script", DEFAULTS["stt_script"]),
+        ]:
+            tk.Label(self, text=key.replace('_', ' ').title()+":").grid(row=row, column=0, sticky="e", padx=5, pady=5)
+            entry = tk.Entry(self, width=50)
+            entry.insert(0, default)
+            entry.grid(row=row, column=1, padx=5, pady=5)
+            btn = tk.Button(self, text="Browse", command=lambda k=key, e=entry: self._browse_file(k, e))
+            btn.grid(row=row, column=2, padx=5, pady=5)
+            self.entries[key] = entry
+            row += 1
+        tk.Button(self, text="Save", command=self.save).grid(row=row, column=0, columnspan=3, pady=10)
+
+    def _browse_file(self, key, entry):
+        path = filedialog.askopenfilename(initialdir=BASE_DIR)
+        if path:
+            rel = os.path.relpath(path, BASE_DIR)
+            entry.delete(0, tk.END)
+            entry.insert(0, rel)
+
+    def save(self):
+        values = {k: self.entries[k].get().strip() for k in self.entries}
+        try:
+            self._update_agent_config(values)
+            self._update_overlay_config(values)
+            messagebox.showinfo("Settings", "Configuration updated successfully.")
+            self.destroy()
+        except Exception as e:
+            messagebox.showerror("Error", f"Failed to update settings: {e}")
+
+    def _update_agent_config(self, values):
+        if not os.path.exists(AGENT_CFG_PATH):
+            return
+        with open(AGENT_CFG_PATH, 'r', encoding='utf-8') as f:
+            cfg = yaml.safe_load(f) or {}
+        overlay = cfg.get('overlay', {})
+        overlay['python'] = values['python']
+        overlay['script'] = values['overlay_script']
+        overlay['cwd'] = os.path.dirname(values['overlay_script'])
+        cfg['overlay'] = overlay
+        with open(AGENT_CFG_PATH, 'w', encoding='utf-8') as f:
+            yaml.safe_dump(cfg, f, allow_unicode=True)
+
+    def _update_overlay_config(self, values):
+        if not os.path.exists(OVERLAY_CFG_PATH):
+            return
+        with open(OVERLAY_CFG_PATH, 'r', encoding='utf-8') as f:
+            cfg = yaml.safe_load(f) or {}
+        tools = cfg.get('tools', {})
+        ocr = tools.get('ocr.start', {})
+        ocr['command'] = values['python']
+        args = ocr.get('args', [values['ocr_script']])
+        if args:
+            args[0] = values['ocr_script']
+        else:
+            args = [values['ocr_script']]
+        ocr['args'] = args
+        ocr['cwd'] = os.path.dirname(values['ocr_script'])
+        tools['ocr.start'] = ocr
+
+        stt = tools.get('stt.start', {})
+        stt['command'] = values['python']
+        sargs = stt.get('args', [values['stt_script']])
+        if sargs:
+            sargs[0] = values['stt_script']
+        else:
+            sargs = [values['stt_script']]
+        stt['args'] = sargs
+        stt['cwd'] = os.path.dirname(values['stt_script'])
+        tools['stt.start'] = stt
+        cfg['tools'] = tools
+        with open(OVERLAY_CFG_PATH, 'w', encoding='utf-8') as f:
+            yaml.safe_dump(cfg, f, allow_unicode=True)
+
+if __name__ == '__main__':
+    SettingsGUI().mainloop()

--- a/Overlay/config.yaml
+++ b/Overlay/config.yaml
@@ -73,9 +73,9 @@ tools:
   ocr.start:
     kind: "process"
     id: "ocr"
-    command: "D:/jip/home-agent/.venv/Scripts/python.exe"
-    args: ["D:/jip/home-agent/OCR/main.py"]
-    cwd: "D:/jip/home-agent/OCR"
+    command: ".venv/Scripts/python.exe"
+    args: ["OCR/main.py"]
+    cwd: "OCR"
     no_console: true
     env:
       AGENT_EVENT_URL: "http://127.0.0.1:8350/event"
@@ -88,9 +88,9 @@ tools:
   stt.start:
     kind: "process"
     id: "stt"
-    command: "D:/jip/home-agent/.venv/Scripts/python.exe"
-    args: ["D:/jip/home-agent/STT/VSRG-Ts-to-kr.py"]
-    cwd: "D:/jip/home-agent/STT"
+    command: ".venv/Scripts/python.exe"
+    args: ["STT/VSRG-Ts-to-kr.py"]
+    cwd: "STT"
     no_console: true
     shell: true
     env:
@@ -104,13 +104,13 @@ tools:
   web.search:
     kind: "process"
     id: "web"
-    command: "D:/jip/home-agent/.venv/Scripts/python.exe"
-    args: ["D:/jip/home-agent/Overlay/plugins/web_search.py",
+    command: ".venv/Scripts/python.exe"
+    args: ["Overlay/plugins/web_search.py",
            "--query", "{q}",
            "--topk", "{k}",
            "--summarize",
            "--post"]
-    cwd: "D:/jip/home-agent/Overlay/plugins"
+    cwd: "Overlay/plugins"
     no_console: false
     env:
       # ✅ Enhanced Web Search 환경변수

--- a/agent/config.yaml
+++ b/agent/config.yaml
@@ -1,30 +1,25 @@
-server:
-  host: "127.0.0.1"
-  port: 8765
-
-policy:
-  autonomy_level: "auto"  # auto | confirm | hybrid
-  batch_seconds: 300
-
-translate:
-  provider: "lmstudio"    # lmstudio | ollama | openai
-  endpoint: "http://127.0.0.1:1234/v1"
-  model: "qwen/qwen3-4b-2507"
-  api_key: ""
-  max_refine_chars: 6500                 # LLM 보낼 최대 글자
-  severity_threshold: 2                  # 0~3: 2 이상이면 LLM 보정 실행
-
-sinks:
-  toast: true
-  log_file: "agent_output.log"
-
 limits:
   dedup_window_seconds: 3600
   max_queue_size: 1000
-
 overlay:
+  args: []
+  cwd: Overlay
   enable: true
-  python: "D:/jip/home-agent/.venv/Scripts/python.exe"      # 루트 venv
-  script: "D:/jip/home-agent/Overlay/overlay_app.py"        # 오버레이 스크립트
-  cwd: "D:/jip/home-agent/Overlay"                         # 작업 디렉터리
-  args: []                                                  # 필요시 인자
+  python: .venv/Scripts/python.exe
+  script: Overlay/overlay_app.py
+policy:
+  autonomy_level: auto
+  batch_seconds: 300
+server:
+  host: 127.0.0.1
+  port: 8765
+sinks:
+  log_file: agent_output.log
+  toast: true
+translate:
+  api_key: ''
+  endpoint: http://127.0.0.1:1234/v1
+  max_refine_chars: 6500
+  model: qwen/qwen3-4b-2507
+  provider: lmstudio
+  severity_threshold: 2

--- a/처음 사용자용 실행 및 설치.bat
+++ b/처음 사용자용 실행 및 설치.bat
@@ -10,6 +10,11 @@ if not exist "%VENV_DIR%\Scripts\python.exe" (
     "%VENV_DIR%\Scripts\python.exe" -m pip install --upgrade pip
     "%VENV_DIR%\Scripts\python.exe" -m pip install -r requirements.txt
 )
+set SETTINGS_SCRIPT=%~dp0Gui_settings.py
+set /p MODIFY_SETTINGS="설정을 수정하시겠습니까? (Y/N): "
+if /I "%MODIFY_SETTINGS%"=="Y" (
+    "%VENV_DIR%\Scripts\python.exe" "%SETTINGS_SCRIPT%"
+)
 
 echo Starting application...
 "%VENV_DIR%\Scripts\python.exe" -m agent.main


### PR DESCRIPTION
## Summary
- Add `Gui_settings.py` to update OCR, STT, Overlay, and agent paths relative to the project
- Default configs now use relative paths for easier relocation
- Startup script asks whether to run the settings GUI before launching

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad7684e02c8333a3c9155c66928e10