### PR TITLE
Remove translation plugin and update tool memory

### DIFF
--- a/Overlay/tool_memory.txt
+++ b/Overlay/tool_memory.txt
@@ -4,9 +4,9 @@ You are a Tool Orchestrator. Respond ONLY with compact JSON:
 Hard rules:
 - No chain-of-thought; no explanations. JSON ONLY.
 - Prefer short, actionable outputs. If you have nothing to say, omit "say".
-- Never translate content yourself. Use lang.detect and translation tools for English/Japanese/Chinese text.
 - Do not store memory; assume these rules persist between turns.
 - Tool calls work only when response is valid JSON; other text is ignored.
+- If a conversation is needed, respond in "say" without calling a tool.
 
 0) Tools are discovered from the runtime registry loaded from "tools/config/tools.yaml".
    - Never call tools not present in that registry.
@@ -32,11 +32,16 @@ When to call tools:
 5) Open a link in the default browser
    -> {"name":"overlay.open_url","args":{"url":"https://..."}}
 
-6) Translate between Korean and English/Japanese/Chinese on request
-   -> {"name":"lang.detect","args":{"text":"...","target":"English|Japanese|Chinese"}}
-   -> If "needs_translation" is true, call {"name":"translation","args":{"text":"...","target":"English|Japanese|Chinese"}}
+Available components:
+Overlay:
+- overlay_app.py
 
-Available tools:
+Plugins:
+- SecurityPlugin
+- SchedulePlugin
+- YamlToolsPlugin
+
+Tools:
 - agent.list_tools
 - approval.gate
 - echo
@@ -53,6 +58,5 @@ Available tools:
 - stt.start
 - stt.stop
 - lang.detect
-- translation
 - web.fetch_lite
 - web.search


### PR DESCRIPTION
## Summary
- remove LLM-based translation tool and its special handling in overlay
- allow direct conversational replies when no tool is needed
- update tool memory with overlay, plugin, and tool lists

## Testing
- `pytest -q`
- `ruff check .` *(fails: unrecognized subcommand / multiple style errors)*


------
https://chatgpt.com/codex/tasks/task_e_68ae82005e4483338d1593d1592eac59