### PR TITLE
Enable semantic activation of OCR and STT tools

### DIFF
--- a/Overlay/overlay_app.py
+++ b/Overlay/overlay_app.py
@@ -642,30 +642,17 @@ class Orchestrator:
         ut = (user_text or "").strip()
         low = ut.lower()
 
-        # 웹검색
+        # 웹검색만 키워드 기반으로 처리
         if ("웹검색" in ut) or ("검색" in ut) or ("search" in low):
             q = ut
-            for kw in ("웹검색","검색","search"):
+            for kw in ("웹검색", "검색", "search"):
                 if kw in ut:
-                    i = ut.find(kw)+len(kw)
+                    i = ut.find(kw) + len(kw)
                     q = ut[i:].strip() or ut
                     break
-            return [{"name":"web.search","args":{"q": q}}]
+            return [{"name": "web.search", "args": {"q": q}}]
 
-        # OCR
-        if ("ocr" in low or "자막" in ut) and any(k in ut for k in ("켜","켜줘","start","시작","시작해")):
-            # 기본 힌트는 subtitle로 전달하여 Tool Memory 지침을 따름
-            return [{"name": "ocr.start", "args": {"hint": "subtitle"}}]
-        if ("ocr" in low or "자막" in ut) and any(k in ut for k in ("꺼","꺼줘","stop","중지","종료","멈춰")):
-            return [{"name":"ocr.stop","args":{}}]
-
-        # STT
-        if "stt" in low and any(k in ut for k in ("켜","켜줘","start","시작","시작해")):
-            # 실시간 모드로 시작하도록 명시
-            return [{"name": "stt.start", "args": {"mode": "realtime"}}]
-        if "stt" in low and any(k in ut for k in ("꺼","꺼줘","stop","중지","종료","멈춰")):
-            return [{"name":"stt.stop","args":{}}]
-
+        # 기타 도구는 LLM에 의해 의미 기반으로 결정되도록 비워둔다
         return []
 
     def _system_prompt_tools(self) -> str:
@@ -819,7 +806,7 @@ A: {"say": "안녕하세요! 무엇을 도와드릴까요?", "tool_calls": []}
         say = scan["masked_text"]
         tc_from_text = parsed.get("tool_calls") or []
 
-        # ③ 휴리스틱(최우선)
+        # ③ 휴리스틱(우선순위 낮음)
         tc_heur = self._heuristic_route(user_text)
 
         # ④ 허용 툴만 통과
@@ -832,15 +819,18 @@ A: {"say": "안녕하세요! 무엇을 도와드릴까요?", "tool_calls": []}
             return ok
 
         tool_calls = []
-        if tc_heur:
-            tool_calls = _filter_ok(tc_heur)
-        elif tc_from_text:
+        if tc_from_text:
             tool_calls = _filter_ok(tc_from_text)
         else:
+            tmp = []
             for tc in tc_openai:
                 it = openai_tc_to_internal(tc)
-                if it: tool_calls.append(it)
-            tool_calls = _filter_ok(tool_calls)
+                if it:
+                    tmp.append(it)
+            if tmp:
+                tool_calls = _filter_ok(tmp)
+            elif tc_heur:
+                tool_calls = _filter_ok(tc_heur)
 
         self.history_tools += [
             {"role":"user","content":user_text},

--- a/tests/test_semantic_tools.py
+++ b/tests/test_semantic_tools.py
@@ -1,0 +1,57 @@
+import types
+import sys
+import os
+import asyncio
+import pytest
+
+# Ensure project root on path
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+# Stub PyQt5 modules for headless testing
+class _QtDummyBase:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+class _QtDummyModule(types.ModuleType):
+    def __getattr__(self, name):  # returns subclassable dummy classes
+        if name == "pyqtSignal":
+            return lambda *a, **k: (lambda *a, **k: None)
+        if name == "pyqtSlot":
+            return lambda *a, **k: (lambda func: func)
+        return _QtDummyBase
+
+
+pyqt = types.ModuleType("PyQt5")
+sys.modules.setdefault("PyQt5", pyqt)
+sys.modules.setdefault("PyQt5.QtCore", _QtDummyModule("QtCore"))
+sys.modules.setdefault("PyQt5.QtGui", _QtDummyModule("QtGui"))
+sys.modules.setdefault("PyQt5.QtWidgets", _QtDummyModule("QtWidgets"))
+
+import Overlay.overlay_app as app
+from Overlay.overlay_app import Orchestrator
+
+
+def test_heuristic_route_only_websearch():
+    orch = Orchestrator({}, window=None)
+    # STT/OCR should not be handled by heuristics anymore
+    assert orch._heuristic_route("자막 켜줘") == []
+    assert orch._heuristic_route("STT 켜줘") == []
+    # Web search remains keyword-based
+    res = orch._heuristic_route("고양이 검색")
+    assert res == [{"name": "web.search", "args": {"q": "고양이 검색"}}]
+
+
+def test_call_tools_prefers_llm(monkeypatch):
+    # Simplify security hooks
+    monkeypatch.setattr(app, "pre_ingest_external", lambda text, meta: {"safe_summary": text})
+    monkeypatch.setattr(app, "before_upload", lambda text, is_file=False: {"masked_text": text})
+    orch = Orchestrator({}, window=None)
+
+    async def fake_chat(llm, msgs):
+        # Simulate LLM suggesting OCR start via function call
+        return {"content": "", "tool_calls": [{"type": "function", "function": {"name": "ocr.start", "arguments": "{}"}}]}
+
+    monkeypatch.setattr(orch, "_chat_complete_raw", fake_chat)
+    out = asyncio.run(orch.call_tools("화면의 글자를 읽어 줘"))
+    assert {"name": "ocr.start", "args": {}} in out["tool_calls"]


### PR DESCRIPTION
## Summary
- Route OCR and STT activation through the LLM by removing keyword heuristics and reordering tool routing
- Add tests demonstrating LLM-based tool activation and remaining web-search heuristics

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae86b75d688333a16891b84a8ea2b6