### PR TITLE
feat: expand ROI OCR, ranking, and rule NLU

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -1,3 +1,7 @@
 - Stable ID 기능 구현 완료.
 - AGENTS.md 및 For Agent readme.txt 업데이트 완료.
 - 이제 Agent Readme의 다른 기능(ROI OCR, ranking, rule NLU, runner, executor 등)을 계속 구현해야 함.
+- ROI OCR 모듈에 행/열 정렬 함수 추가로 텍스트 순서 안정화. 전체 PaddleOCR 연동 및 나머지 기능은 아직 구현 필요.
+- ROI OCR 다국어 PaddleOCR 연동 골격과 ROI 백오프 로직 추가. 화면 캡처/절대좌표 변환 등 실사용 연동은 계속 필요.
+- 랭킹 모듈에 Feature/Candidate 구조와 정규화 점수 기반 정렬 함수 구현. 실제 UIA feature 추출 연동 필요.
+- Rule NLU에 다음/이전 줄, 철자, 숫자 등 규칙 확장 및 DSL 형태 반환. 복잡한 의도 파서는 LLM으로 위임 예정.

--- a/src/core/ranking.py
+++ b/src/core/ranking.py
@@ -5,9 +5,34 @@ Alternatives: train ML ranker
 Rationale: deterministic formula for explainability
 """
 
-def rank(feat):
-    score = 0.52*feat.text + 0.18*feat.role + 0.20*feat.near + 0.10*feat.spatial - 0.05*feat.disabled
+from dataclasses import dataclass
+from typing import Iterable, List
+
+
+@dataclass
+class Features:
+    text: float = 0.0
+    role: float = 0.0
+    near: float = 0.0
+    spatial: float = 0.0
+    disabled: float = 0.0
+
+
+def rank(feat: Features) -> float:
+    score = 0.52 * feat.text + 0.18 * feat.role + 0.20 * feat.near + 0.10 * feat.spatial - 0.05 * feat.disabled
     return score
+
+
+@dataclass
+class Candidate:
+    id: str
+    features: Features
+
+
+def rank_candidates(cands: Iterable[Candidate]) -> List[Candidate]:
+    """Return candidates sorted by ranking score descending."""
+
+    return sorted(cands, key=lambda c: rank(c.features), reverse=True)
 # Checklist:
 # - [x] Think Harder
 # - [x] Think Deeper

--- a/src/core/roi_ocr.py
+++ b/src/core/roi_ocr.py
@@ -5,15 +5,112 @@ Alternatives: full-screen OCR or multi-scale search
 Rationale: small crops reduce latency
 """
 
-def collect_roi(cursor, scale=1.0, backoff=1.4, max_attempts=2, topk=5, conf_min=0.6, langs=("ko", "en", "ja", "zh")):
+from dataclasses import dataclass
+from typing import Iterable, List, Tuple
+
+try:  # pragma: no cover - optional dependency
+    from paddleocr import PaddleOCR
+except Exception:  # pragma: no cover - PaddleOCR not installed
+    PaddleOCR = None
+
+
+@dataclass
+class OcrBox:
+    x1: int
+    y1: int
+    x2: int
+    y2: int
+    text: str
+    conf: float
+
+    @property
+    def center_x(self) -> float:
+        return (self.x1 + self.x2) / 2
+
+    @property
+    def center_y(self) -> float:
+        return (self.y1 + self.y2) / 2
+
+    def move(self, offset: Tuple[int, int]) -> "OcrBox":
+        ox, oy = offset
+        return OcrBox(self.x1 + ox, self.y1 + oy, self.x2 + ox, self.y2 + oy, self.text, self.conf)
+
+
+@dataclass
+class ROI:
+    offset: Tuple[int, int]
+    image: object | None = None
+
+
+def crop(cursor: Tuple[int, int], scale: float) -> ROI:
+    """Stub for cropping an ROI around ``cursor``.
+
+    Real implementation should capture pixels around the cursor.  This stub
+    simply returns an offset used to translate OCR boxes back to absolute
+    coordinates.
+    """
+
+    size = int(100 * scale)
+    x, y = cursor
+    return ROI(offset=(x - size // 2, y - size // 2))
+
+
+def to_absolute(box: OcrBox, offset: Tuple[int, int]) -> OcrBox:
+    return box.move(offset)
+
+
+def sort_ocr_boxes(boxes: Iterable[OcrBox]) -> List[OcrBox]:
+    """Return boxes sorted in row-major order.
+
+    PaddleOCR sometimes emits results in an arbitrary sequence which can
+    shuffle reading order.  Sorting by the bounding-box centre coordinates
+    (top-to-bottom, then left-to-right) stabilises the output and simplifies
+    downstream reconstruction of lines.
+    """
+
+    return sorted(boxes, key=lambda b: (b.center_y, b.center_x))
+
+
+def collect_roi(
+    cursor: Tuple[int, int],
+    scale: float = 1.0,
+    backoff: float = 1.4,
+    max_attempts: int = 2,
+    topk: int = 5,
+    conf_min: float = 0.6,
+    langs: Tuple[str, ...] = ("ko", "en", "ja", "zh"),
+) -> List[OcrBox]:
+    """Collect OCR boxes around the cursor with exponential backoff.
+
+    Attempts OCR in multiple languages, filtering low-confidence results and
+    returning the top ``topk`` boxes in reading order.  Raises if PaddleOCR is
+    unavailable so callers can decide on a fallback strategy.
+    """
+
+    if PaddleOCR is None:  # pragma: no cover - dependency optional in tests
+        raise RuntimeError("PaddleOCR not installed")
+
     engines = {l: PaddleOCR(use_angle_cls=True, lang=l) for l in langs}
     for _ in range(max_attempts):
         roi = crop(cursor, scale)
-        boxes = []
-        for l in langs:
-            boxes.extend(engines[l].ocr(roi))
+        boxes: List[OcrBox] = []
+        for lang, eng in engines.items():  # pragma: no cover - heavy runtime
+            try:
+                results = eng.ocr(roi.image) if roi.image is not None else []
+            except Exception:
+                results = []
+            for box, (text, conf) in results:
+                b = OcrBox(
+                    x1=int(box[0][0]),
+                    y1=int(box[0][1]),
+                    x2=int(box[2][0]),
+                    y2=int(box[2][1]),
+                    text=text,
+                    conf=float(conf),
+                )
+                boxes.append(b)
         boxes = [b for b in boxes if b.conf >= conf_min]
-        boxes.sort(key=lambda b: (-b.conf, b.center_y, b.center_x))
+        boxes = sort_ocr_boxes(boxes)
         if boxes:
             return [to_absolute(b, roi.offset) for b in boxes[:topk]]
         scale *= backoff

--- a/src/core/rule_nlu.py
+++ b/src/core/rule_nlu.py
@@ -5,10 +5,31 @@ Alternatives: send all to LLM
 Rationale: reduce latency by skipping LLM
 """
 
-def rule_nlu(utter, candidates):
-    if utter in ("멈춰", "정지"): return {"action": "stop"}
-    if utter.startswith("번역"): return {"action": "translate"}
-    matches = [c for c in candidates if c.text in utter]
+from typing import Iterable, Optional
+
+
+def rule_nlu(utter: str, candidates: Iterable) -> Optional[dict]:
+    """Very small rule set for common utterances.
+
+    Returns a DSL-like dict describing the action or ``None`` if the utterance
+    should fall back to the LLM intent classifier.
+    """
+
+    utter = utter.strip()
+    if utter in ("멈춰", "정지", "stop"):
+        return {"action": "stop"}
+    if utter.startswith("번역"):
+        return {"action": "translate"}
+    if utter in ("다음 줄", "다음", "next"):
+        return {"action": "next_line"}
+    if utter in ("이전 줄", "이전", "prev"):
+        return {"action": "prev_line"}
+    if utter.startswith("철자"):
+        return {"action": "spell"}
+    if utter.startswith("숫자"):
+        return {"action": "numbers"}
+
+    matches = [c for c in candidates if getattr(c, "text", "") and c.text in utter]
     if len(matches) == 1:
         return {"action": "read", "target": {"id": matches[0].id}}
     if len(matches) > 1:


### PR DESCRIPTION
## Summary
- scaffold ROI OCR with PaddleOCR backoff, sorting, and absolute coordinate helpers
- add feature and candidate models with deterministic ranking formula and sorter
- broaden rule-based NLU to handle navigation, spelling, and numbers commands

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement paddlepaddle>=2.5.1)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b23fbe99e48333b605104e3dcd1c5f