### PR TITLE
feat: simplify runner and add executor

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -5,3 +5,6 @@
 - ROI OCR 다국어 PaddleOCR 연동 골격과 ROI 백오프 로직 추가. 화면 캡처/절대좌표 변환 등 실사용 연동은 계속 필요.
 - 랭킹 모듈에 Feature/Candidate 구조와 정규화 점수 기반 정렬 함수 구현. 실제 UIA feature 추출 연동 필요.
 - Rule NLU에 다음/이전 줄, 철자, 숫자 등 규칙 확장 및 DSL 형태 반환. 복잡한 의도 파서는 LLM으로 위임 예정.
+- Runner 모듈을 단순화하여 두 단계 LLM 호출만 수행하도록 수정. LM Studio/Ollama 환경 가정 하에 동작.
+- Executor 모듈에 UIA 우선 실행과 좌표/키보드/ OCR 대체 로직이 담긴 최소 구현 추가. 실제 UIA 연동과 위험
+  명령 확인 절차 고도화가 필요.

--- a/src/core/executor.py
+++ b/src/core/executor.py
@@ -1,34 +1,108 @@
-"""
-Assumptions: UIA resolution succeeds most of time
-Risks: wrong element gets activated
-Alternatives: always ask confirmation
-Rationale: UIA pattern then coordinate fallback for robustness
+"""Minimal DSL executor.
+
+The executor prefers UIA actions and falls back to coordinates or OCR when an
+appropriate UI Automation pattern is unavailable.  It assumes the environment
+already has a local LLM stack (e.g. LM Studio or Ollama) for higher level
+reasoning.
 """
 
-def execute(dsl):
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class Element:
+    """Tiny stand‑in for a UI Automation element."""
+
+    id: str
+    capabilities: set[str]
+
+    def invoke(self) -> str:
+        return f"invoked:{self.id}"
+
+    def set_value(self, value: str) -> str:
+        return value
+
+    def select(self, text: str) -> str:
+        return text
+
+
+# ----- helpers --------------------------------------------------------------
+
+
+def is_dangerous(dsl: Dict[str, Any]) -> bool:
+    return dsl.get("dangerous", False)
+
+
+def confirm_with_wake() -> bool:
+    return True
+
+
+def resolve_uia(tid: Optional[str]) -> Optional[Element]:
+    return Element(tid, {"invoke", "value", "selection"}) if tid else None
+
+
+def has_invoke(el: Element) -> bool:
+    return "invoke" in el.capabilities
+
+
+def has_value(el: Element) -> bool:
+    return "value" in el.capabilities
+
+
+def has_selection(el: Element) -> bool:
+    return "selection" in el.capabilities
+
+
+def click_center(tid: str) -> str:
+    return f"click:{tid}"
+
+
+def type_fallback(value: str) -> str:
+    return f"typed:{value}"
+
+
+def ocr_click_by_text(text: str) -> str:
+    return f"ocr:{text}"
+
+
+def send_key(params: Dict[str, Any]) -> Dict[str, Any]:
+    return params
+
+
+# ----- main -----------------------------------------------------------------
+
+
+def execute(dsl: Dict[str, Any]) -> Any:
+    """Execute a simple DSL action dictionary."""
+
     if is_dangerous(dsl) and not confirm_with_wake():
         return "cancelled"
+
     tid = dsl.get("target", {}).get("id")
     el = resolve_uia(tid)
-    a = dsl["action"]
-    if a == "invoke":
+    action = dsl["action"]
+
+    if action == "invoke":
         if el and has_invoke(el):
             return el.invoke()
         return click_center(tid)
-    if a == "set_value":
+
+    if action == "set_value":
         val = dsl["params"]["value"]
         if el and has_value(el):
             return el.set_value(val)
         return type_fallback(val)
-    if a == "select":
-        txt = dsl["params"].get("text")
+
+    if action == "select":
+        txt = dsl["params"].get("text", "")
         if el and has_selection(el):
             return el.select(txt)
         return ocr_click_by_text(txt)
-    if a in ("key", "hotkey"):
+
+    if action in ("key", "hotkey"):
         return send_key(dsl["params"])
-# Checklist:
-# - [x] Think Harder
-# - [x] Think Deeper
-# - [x] More Information
-# - [x] Check Again
+
+    raise ValueError(f"unknown action: {action}")

--- a/src/core/runner.py
+++ b/src/core/runner.py
@@ -1,23 +1,64 @@
-"""
-Assumptions: LLM expose timeout flag and token usage
-Risks: repeated timeouts waste budget
-Alternatives: early clarify without retry
-Rationale: bounded latency with one retry at +50%
+"""Lightweight two-stage LLM runner without latency management.
+
+Assumes a local LLM backend such as LM Studio or Ollama is installed and
+available. The runner simply asks the model once and parses out optional
+``<think>`` and answer segments.
+
+Risks
+-----
+Any model stall or failure surfaces directly to the caller without retries.
+
+Alternatives
+------------
+A higher level supervisor could implement retries or clarification flows.
+
+Rationale
+---------
+Keep the runner minimal so it works with locally hosted models.
 """
 
-def run_two_stage(task, prompt, think_budget, answer_budget, timeout_ms):
-    for attempt in range(2):
-        result = llm.generate(prompt, max_tokens=think_budget+answer_budget,
-                              stop=["</think>", "}\n\n"], timeout=timeout_ms)
-        if result.timeout and attempt == 0 and timeout_ms <= 600:
-            think_budget = int(think_budget * 1.5)
-            answer_budget = int(answer_budget * 1.5)
-            timeout_ms = int(timeout_ms * 1.5)
-            continue
-        return parse(result)
-    return {"error": "timeout"}
-# Checklist:
-# - [x] Think Harder
-# - [x] Think Deeper
-# - [x] More Information
-# - [x] Check Again
+from __future__ import annotations
+
+from typing import Dict, Protocol
+
+
+class _LLM(Protocol):
+    """Minimal protocol for the LLM used in ``run_two_stage``."""
+
+    def generate(
+        self,
+        prompt: str,
+        *,
+        max_tokens: int,
+        stop: list[str],
+    ) -> Dict[str, object]:
+        ...
+
+
+def _parse(text: str) -> Dict[str, str]:
+    """Parse the LLM output into ``think`` and ``answer`` sections."""
+
+    think = ""
+    answer = text
+    start = text.find("<think>")
+    end = text.find("</think>")
+    if start != -1 and end != -1 and end > start:
+        think = text[start + len("<think>") : end].strip()
+        answer = text[end + len("</think>") :].strip()
+    return {"think": think, "answer": answer}
+
+
+def run_two_stage(
+    llm: _LLM,
+    prompt: str,
+    think_budget: int,
+    answer_budget: int,
+) -> Dict[str, str]:
+    """Ask ``llm`` once and parse out ``think`` and ``answer`` segments."""
+
+    result = llm.generate(
+        prompt,
+        max_tokens=think_budget + answer_budget,
+        stop=["</think>", "}\n\n"],
+    )
+    return _parse(str(result.get("text", "")))

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,0 +1,49 @@
+import os, sys
+
+sys.path.append(os.path.abspath('.'))
+import src.core.executor as executor
+
+
+class Elem:
+    def __init__(self, caps):
+        self.capabilities = caps
+        self.invoked = False
+        self.value = None
+        self.selected = None
+
+    def invoke(self):
+        self.invoked = True
+        return "invoked"
+
+    def set_value(self, v):
+        self.value = v
+        return v
+
+    def select(self, t):
+        self.selected = t
+        return t
+
+
+def test_invoke_prefers_uia(monkeypatch):
+    e = Elem({"invoke"})
+    monkeypatch.setattr(executor, "resolve_uia", lambda tid: e)
+    res = executor.execute({"action": "invoke", "target": {"id": "1"}, "params": {}})
+    assert res == "invoked" and e.invoked
+
+
+def test_set_value_fallback(monkeypatch):
+    monkeypatch.setattr(executor, "resolve_uia", lambda tid: None)
+    monkeypatch.setattr(executor, "type_fallback", lambda v: f"typed:{v}")
+    res = executor.execute({
+        "action": "set_value",
+        "target": {"id": "1"},
+        "params": {"value": "hi"},
+    })
+    assert res == "typed:hi"
+
+
+def test_danger_cancel(monkeypatch):
+    monkeypatch.setattr(executor, "is_dangerous", lambda d: True)
+    monkeypatch.setattr(executor, "confirm_with_wake", lambda: False)
+    res = executor.execute({"action": "invoke", "target": {"id": "1"}, "params": {}})
+    assert res == "cancelled"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,31 @@
+import os, sys
+
+sys.path.append(os.path.abspath('.'))
+from src.core.runner import run_two_stage
+
+
+class DummyLLM:
+    def __init__(self):
+        self.calls = []
+
+    def generate(self, prompt, *, max_tokens, stop):
+        self.calls.append({'max_tokens': max_tokens, 'stop': stop})
+        return {'text': '<think>t</think>out'}
+
+
+def test_single_call_and_parse():
+    llm = DummyLLM()
+    res = run_two_stage(llm, 'p', 10, 20)
+    assert res == {'think': 't', 'answer': 'out'}
+    assert llm.calls == [{'max_tokens': 30, 'stop': ['</think>', '}\n\n']}]
+
+
+class PlainLLM:
+    def generate(self, prompt, *, max_tokens, stop):
+        return {'text': 'hello'}
+
+
+def test_no_think_segment():
+    llm = PlainLLM()
+    res = run_two_stage(llm, 'p', 5, 5)
+    assert res == {'think': '', 'answer': 'hello'}


### PR DESCRIPTION
## Summary
- simplify two-stage LLM runner to single call with local LM Studio/Ollama assumption
- implement minimal executor with UIA-first actions and fallbacks
- document progress in working memory and add tests for runner and executor

## Testing
- `pip install -r requirements.txt || true`
- `ruff check .` *(fails: undefined names and lint errors in existing code)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b241fd9ea08333a8d157bdaf3ef6fa