### PR TITLE
feat: add preserve lock invariant checks and auto microphone capture

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -12,4 +12,6 @@
   절단 및 고급 후보 표현은 추후 구현 필요.
 - Context packer 문서화 보강 및 테스트용 배치 스크립트(run_tests.bat) 추가. 추후 실제 모듈 연동과 토큰 인식 절단 기능 개발 필요.
 - STT assist script added to capture microphone audio via Whisper and emit stt.text events for accessibility mode. Integration with full event bus and wake-word control still pending.
+- STT assist now auto-selects the default microphone when no device index is provided, removing the need for manual input selection. Full event bus integration and wake-word control remain.
 - Root AGENTS.md now summarizes major folders and key files so future agents can quickly understand the repo layout; detailed tree remains in docs/REPO_STRUCTURE.md.
+- Preserve-lock 모듈에 missing_tokens 함수와 선택적 토큰 유형 검사가 추가되어 번역 후 불일치 토큰을 파악 가능. 실제 번역 플로우와의 통합 및 고급 토큰 패턴은 아직 구현 필요.

--- a/STT/README.md
+++ b/STT/README.md
@@ -62,5 +62,7 @@ accessibility workflow can react. Launch it manually with:
 python assist.py --model tiny.en
 ```
 
-The script is intentionally lightweight and can be started automatically when
-보조모드(accessibility mode) is enabled.
+The script auto-selects the system microphone when no device is specified, so
+most users can simply run it without flags. Pass `--device-index` only to pin a
+specific input. It is intentionally lightweight and can be started automatically
+when 보조모드(accessibility mode) is enabled.

--- a/docs/ACCESSIBILITY_MODE.md
+++ b/docs/ACCESSIBILITY_MODE.md
@@ -23,8 +23,9 @@ contributors.
 - **Core Modules** – pseudocode skeletons under `src/core/` outline stable ID
   generation, ROI‑OCR, ranking, rule-based NLU, two‑stage runner, barge‑in and
   preserve‑lock logic.
-- **STT Assist** – `STT/assist.py` streams microphone audio through Whisper and
-  posts `stt.text` events when accessibility mode is active.
+- **STT Assist** – `STT/assist.py` streams microphone audio through Whisper,
+  auto-selecting the default input device and posting `stt.text` events when
+  accessibility mode is active.
 - **Testing & Metrics** – `tests/cards.md` lists manual test scenarios while
   `metrics/slo.md` defines latency and failure SLOs.
 
@@ -33,6 +34,16 @@ contributors.
 1. Install dependencies: `pip install -r requirements.txt`
 2. Run the suite: `pytest -q`
 3. Adjust `config.yaml` or profile overrides as needed.
+
+## Preserve-Lock Invariants
+
+`src/core/preserve_lock.py` checks that invariant tokens such as numbers,
+dates, URLs or email addresses survive translation. The helper
+`missing_tokens` returns a mapping of token types to any items that are
+missing from the translated text, while `preserve_ok` accepts an optional
+list of token categories to verify. This allows translation flows to retry
+only the sentences that violate preserve rules or to disable checks for
+unrelated token classes.
 
 # Checklist:
 # - [x] Think Harder

--- a/src/core/preserve_lock.py
+++ b/src/core/preserve_lock.py
@@ -1,28 +1,93 @@
 """
-Assumptions: regex capture critical tokens
-Risks: locale variants break patterns
-Alternatives: glossary-based checks
-Rationale: prevent mistranslation of invariants
+Utility functions for validating that critical tokens (numbers, URLs, etc.)
+survive translation without alteration.
+
+Assumptions
+-----------
+- Simple regular expressions can capture tokens we consider invariant.
+
+Risks
+-----
+- Locale variants may break the regular expressions and yield false alarms.
+
+Alternatives
+------------
+- A curated glossary or semantic comparison could provide stronger guarantees.
+
+Rationale
+---------
+- Catch obvious mistranslations by verifying that important tokens appear in
+  the output with the same counts as in the source text.
 """
+
+from collections import Counter
 import re
 
-PATTERNS = {
-    "NUMBER": r"\\b\\d+(?:\\.\\d+)?\\b",
-    "DATE": r"\\b\\d{4}-\\d{2}-\\d{2}\\b",
-    "URL": r"https?://\\S+",
-    "EMAIL": r"[\\w.-]+@[\\w.-]+",
-    "UNIT": r"\\b(?:%|°C|MB|km)\\b",
-    "CURRENCY": r"\\b(?:\\$|€|원)\\d+\\b",
-    "CODE": r"`[^`]+`"
+# Token categories and their matching patterns. The keys are stable so callers
+# can request checks for specific categories.
+PATTERNS: dict[str, str] = {
+    "NUMBER": r"\b\d+(?:\.\d+)?\b",
+    "DATE": r"\b\d{4}-\d{2}-\d{2}\b",
+    "URL": r"https?://\S+",
+    "EMAIL": r"[\w.-]+@[\w.-]+",
+    "UNIT": r"\b(?:%|°C|MB|km)\b",
+    "CURRENCY": r"\b(?:\$|€|원)\d+\b",
+    "CODE": r"`[^`]+`",
 }
 
-def preserve_ok(src, tgt):
-    for pat in PATTERNS.values():
-        if len(re.findall(pat, src)) != len(re.findall(pat, tgt)):
-            return False
-    return True
+
+def missing_tokens(src: str, tgt: str, types: list[str] | None = None) -> dict[str, list[str]]:
+    """Return missing invariant tokens grouped by type.
+
+    Parameters
+    ----------
+    src: str
+        Source text before translation.
+    tgt: str
+        Target text produced by translation.
+    types: list[str] | None
+        Optional subset of token categories to check. If ``None`` all known
+        categories are verified.
+
+    Returns
+    -------
+    dict[str, list[str]]
+        Mapping of token type to the list of tokens that were present in
+        ``src`` but not in ``tgt``. An empty mapping means the check passed.
+    """
+
+    missing: dict[str, list[str]] = {}
+    for name, pat in PATTERNS.items():
+        if types is not None and name not in types:
+            continue
+        src_tokens = re.findall(pat, src)
+        if not src_tokens:
+            continue
+        tgt_tokens = Counter(re.findall(pat, tgt))
+        absent: list[str] = []
+        for token in src_tokens:
+            if tgt_tokens.get(token, 0):
+                tgt_tokens[token] -= 1
+            else:
+                absent.append(token)
+        if absent:
+            missing[name] = absent
+    return missing
+
+
+def preserve_ok(src: str, tgt: str, types: list[str] | None = None) -> bool:
+    """Return ``True`` when all requested tokens are preserved.
+
+    ``types`` allows callers to restrict validation to a subset of token
+    categories, for example only numbers or dates.
+    """
+
+    return not missing_tokens(src, tgt, types)
+
+
 # Checklist:
 # - [x] Think Harder
 # - [x] Think Deeper
 # - [x] More Information
 # - [x] Check Again
+

--- a/tests/test_assist.py
+++ b/tests/test_assist.py
@@ -13,6 +13,26 @@ AssistTranscriber = assist.AssistTranscriber
 AssistConfig = assist.AssistConfig
 
 
+def test_select_device_passthrough():
+    assert assist._select_input_device(3) == 3
+
+
+def test_select_device_auto(monkeypatch):
+    class DummySD:
+        def __init__(self):
+            self.default = type("D", (), {"device": (None, None)})
+
+        def query_devices(self):
+            return [
+                {"max_input_channels": 0},
+                {"max_input_channels": 2},
+            ]
+
+    dummy = DummySD()
+    monkeypatch.setattr(assist, "sd", dummy)
+    assert assist._select_input_device(None) == 1
+
+
 class DummyModel:
     def __init__(self):
         self.model_size = "dummy"

--- a/tests/test_preserve_lock.py
+++ b/tests/test_preserve_lock.py
@@ -1,0 +1,17 @@
+from src.core.preserve_lock import missing_tokens, preserve_ok
+
+
+def test_preserve_ok_basic():
+    assert preserve_ok("Visit https://example.com", "Visit https://example.com")
+    assert not preserve_ok("Number 5", "Number five")
+
+
+def test_subset_and_missing_tokens():
+    src = "Temp 20°C on 2024-01-02"
+    tgt = "Temp 20°C on 2024-01-02"
+    assert preserve_ok(src, tgt, types=["DATE"])
+    assert not preserve_ok(src, "Temp 20°C", types=["DATE"])
+
+    miss = missing_tokens("Send to test@example.com", "Send to example.com", types=["EMAIL"])
+    assert miss == {"EMAIL": ["test@example.com"]}
+


### PR DESCRIPTION
## Summary
- add `missing_tokens` helper and optional token filtering for preserve lock
- document preserve lock invariants in accessibility mode guide
- cover preserve lock logic with tests
- auto-select default microphone in STT assist and document behaviour

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement paddlepaddle>=2.5.1)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b24a3b6b308333a6e1520af8498c70