### PR TITLE
Fix agent.list_tools crash and add assist mode toggles

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -15,3 +15,5 @@
 - STT assist now auto-selects the default microphone when no device index is provided, removing the need for manual input selection. Full event bus integration and wake-word control remain.
 - Root AGENTS.md now summarizes major folders and key files so future agents can quickly understand the repo layout; detailed tree remains in docs/REPO_STRUCTURE.md.
 - Preserve-lock 모듈에 missing_tokens 함수와 선택적 토큰 유형 검사가 추가되어 번역 후 불일치 토큰을 파악 가능. 실제 번역 플로우와의 통합 및 고급 토큰 패턴은 아직 구현 필요.
+- Overlay agent.list_tools calls are now invoked via the Qt event loop to prevent crashes when the LLM requests tool listings. Accessibility mode can be toggled with `/assist on|off` and debug logging via `/assist debug on|off`. Full wake‑word handling and deeper event bus wiring for assist mode remain outstanding.
+- In accessibility mode, the overlay now auto-starts microphone STT when minimized to the system tray and stops it when the window is restored, keeping assistive voice control active in the background.


### PR DESCRIPTION
## Summary
- Prevent Overlay from crashing when the LLM calls `agent.list_tools` by queueing tool display on the Qt event loop
- Add `/assist on|off` and `/assist debug on|off` slash commands with logging to toggle accessibility mode and its debug output
- Auto-start microphone STT while the overlay is hidden in tray during accessibility mode so voice control remains active
- Document recent progress in `Agent memory for working.txt`

## Testing
- `pip install -r requirements.txt` *(fails: No matching distribution found for paddlepaddle>=2.5.1)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b24e001e948333bdbfe34a796f776e