### PR TITLE
feat: add assist mode STT and OCR support

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -19,3 +19,4 @@
 - In accessibility mode, the overlay now auto-starts microphone STT when minimized to the system tray and stops it when the window is restored, keeping assistive voice control active in the background.
 - Centralized configuration: merged agent, overlay, STT, and OCR settings into root config.yaml so all components share a single config source.
 - Added bilingual inline comments to config.yaml and created CONFIGURATION.md for English/Korean docs.
+- Assist mode now launches assist-specific STT and PaddleOCR modules via agent events, with periodic status logging and an /assist/status endpoint. Voice-command triggers and debug capture remain to be implemented.

--- a/OCR/OCR-Assist.py
+++ b/OCR/OCR-Assist.py
@@ -1,0 +1,72 @@
+"""Assistive OCR script using PaddleOCR.
+Captures the full screen and posts recognized text to the agent event bus."""
+from __future__ import annotations
+
+import os
+import io
+from typing import List
+
+import numpy as np
+from PIL import Image
+from mss import mss
+import requests
+
+try:  # PaddleOCR is heavy; import lazily
+    from paddleocr import PaddleOCR
+except Exception:  # pragma: no cover - runtime dependency
+    PaddleOCR = None
+
+_EVENT_URL = (
+    os.environ.get("EVENT_URL")
+    or os.environ.get("AGENT_EVENT_URL")
+    or os.environ.get("OVERLAY_EVENT_URL")
+    or "http://127.0.0.1:8350/event"
+)
+_EVENT_KEY = os.environ.get("EVENT_KEY") or os.environ.get("AGENT_EVENT_KEY")
+
+
+def _post_event(_type: str, _payload: dict, _prio: int = 5) -> None:
+    try:
+        headers = {"Content-Type": "application/json"}
+        if _EVENT_KEY:
+            headers["X-Agent-Key"] = _EVENT_KEY
+        requests.post(
+            _EVENT_URL,
+            json={"type": _type, "payload": _payload, "priority": _prio},
+            headers=headers,
+            timeout=3,
+        )
+    except Exception:
+        pass
+
+
+def _capture_screen() -> Image.Image:
+    with mss() as sct:
+        shot = sct.grab(sct.monitors[1])
+        img = Image.frombytes("RGB", shot.size, shot.rgb)
+        return img
+
+
+def _run_ocr(img: Image.Image) -> str:
+    if PaddleOCR is None:
+        raise RuntimeError("paddleocr is not installed")
+    ocr = PaddleOCR(use_angle_cls=True, lang="korean")
+    np_img = np.array(img)
+    result = ocr.ocr(np_img, cls=True)
+    lines: List[str] = []
+    for line in result:
+        for item in line:
+            lines.append(item[1][0])
+    return "\n".join(lines).strip()
+
+
+def main() -> None:
+    img = _capture_screen()
+    text = _run_ocr(img)
+    if text:
+        _post_event("ocr.text", {"text": text, "source": "paddle_assist"})
+        print(text)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/agent/context.py
+++ b/agent/context.py
@@ -14,6 +14,8 @@ class Ctx:
         )
         self.policy = Policy(config["policy"]["autonomy_level"])
         self.sinks = sinks_mod
+        # Accessibility/assistive mode flag (persisted until toggled off)
+        self.assist_mode: bool = bool(config.get("accessibility", 0))
 
 def load_config(path: str = "config.yaml") -> Dict[str, Any]:
     with open(path, "r", encoding="utf-8") as f:

--- a/config.yaml
+++ b/config.yaml
@@ -148,6 +148,33 @@ overlay:
       kind: "process_stop"
       id: "stt"
       method: "terminate"
+    stt_assist.start:
+      kind: "process"
+      id: "stt"
+      command: "D:/jip/home-agent/.venv/Scripts/python.exe"
+      args: ["D:/jip/home-agent/STT/assist.py"]
+      cwd: "D:/jip/home-agent/STT"
+      no_console: true
+      shell: true
+      env:
+        AGENT_EVENT_URL: "http://127.0.0.1:8350/event"
+    stt_assist.stop:
+      kind: "process_stop"
+      id: "stt"
+      method: "terminate"
+    ocr_assist.start:
+      kind: "process"
+      id: "ocr"
+      command: "D:/jip/home-agent/.venv/Scripts/python.exe"
+      args: ["D:/jip/home-agent/OCR/OCR-Assist.py"]
+      cwd: "D:/jip/home-agent/OCR"
+      no_console: true
+      env:
+        AGENT_EVENT_URL: "http://127.0.0.1:8350/event"
+    ocr_assist.stop:
+      kind: "process_stop"
+      id: "ocr"
+      method: "terminate"
     web.search:
       kind: "process"
       id: "web"


### PR DESCRIPTION
## Summary
- track assist mode state on agent server and spawn dedicated STT/OCR processes
- show live captions in assist STT via SubtitleUI
- introduce PaddleOCR-based OCR-Assist script and config entries

## Testing
- `pip install -r requirements.txt` (fails: Could not find a version that satisfies the requirement paddlepaddle>=2.5.1)
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2572688548333bf26f8361cdf4b7c