### PR TITLE
feat: add espeak tts module and config

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -20,3 +20,5 @@
 - Centralized configuration: merged agent, overlay, STT, and OCR settings into root config.yaml so all components share a single config source.
 - Added bilingual inline comments to config.yaml and created CONFIGURATION.md for English/Korean docs.
 - Assist mode now launches assist-specific STT and PaddleOCR modules via agent events, with periodic status logging and an /assist/status endpoint. Voice-command triggers and debug capture remain to be implemented.
+- STT Assist now reads a dedicated Assist-config via a batch script and runs faster-whisper small int8 on CPU. OCR Assist plays a "찍었습니다." TTS cue using eSpeak NG on CPU after capturing text.
+- Added eSpeak NG TTS configuration with pronunciation rules; OCR Assist now uses shared eSpeak module.

--- a/OCR/OCR-Assist.py
+++ b/OCR/OCR-Assist.py
@@ -3,13 +3,13 @@ Captures the full screen and posts recognized text to the agent event bus."""
 from __future__ import annotations
 
 import os
-import io
 from typing import List
 
 import numpy as np
 from PIL import Image
 from mss import mss
 import requests
+from tools.tts_espeak import speak
 
 try:  # PaddleOCR is heavy; import lazily
     from paddleocr import PaddleOCR
@@ -60,12 +60,14 @@ def _run_ocr(img: Image.Image) -> str:
     return "\n".join(lines).strip()
 
 
+
 def main() -> None:
     img = _capture_screen()
     text = _run_ocr(img)
     if text:
         _post_event("ocr.text", {"text": text, "source": "paddle_assist"})
         print(text)
+        speak("찍었습니다.", lang="ko")
 
 
 if __name__ == "__main__":  # pragma: no cover - manual execution

--- a/STT/Assist-config.yaml
+++ b/STT/Assist-config.yaml
@@ -1,0 +1,11 @@
+stt:
+  engine: faster-whisper
+  model: small           # multilingual
+  compute_type: int8     # CPU friendly
+  language: auto         # auto-detect ko/en/ja/zh
+  vad: silero            # or webrtcvad
+  chunk_sec: 7
+  chunk_overlap_sec: 0.5
+  beam_size: 3
+  condition_on_previous_text: false   # avoid hallucination accumulation
+  temperature_fallback: [0.0, 0.2, 0.4]

--- a/STT/assist_start.bat
+++ b/STT/assist_start.bat
@@ -1,0 +1,2 @@
+@echo off
+"%~dp0..\.venv\Scripts\python.exe" "%~dp0assist.py" --config "%~dp0Assist-config.yaml"

--- a/config.yaml
+++ b/config.yaml
@@ -151,8 +151,8 @@ overlay:
     stt_assist.start:
       kind: "process"
       id: "stt"
-      command: "D:/jip/home-agent/.venv/Scripts/python.exe"
-      args: ["D:/jip/home-agent/STT/assist.py"]
+      command: "D:/jip/home-agent/STT/assist_start.bat"
+      args: []
       cwd: "D:/jip/home-agent/STT"
       no_console: true
       shell: true
@@ -313,6 +313,21 @@ stt:
     model: "tiny.en"
     compute_type: "int8"
     rms_gate_dbfs: -35.0
+
+# TTS settings
+# TTS 설정
+tts:
+  backend_order: ["espeak-ng"]
+  espeak_ng:
+    voices: { ko: "ko", en: "en-us", ja: "ja", zh: "zh" }
+    rate: "+10"
+    pitch: 0
+    volume: 100
+    word_gap_ms: 20
+    sample_rate: 22050
+    chunk_ms: 1200
+    buffer_ms: 300
+    wav_cache: true
 
 # Voice command settings
 # 음성 명령 설정

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,8 @@ scikit-learn>=1.3.0
 pycaw>=20231210
 comtypes>=1.2.0
 
+# eSpeak NG for assistive feedback (system package)
+
 # Web search helpers
 duckduckgo-search>=5.3.0
 beautifulsoup4>=4.12.3

--- a/tools/tts_espeak.py
+++ b/tools/tts_espeak.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+"""eSpeak NG TTS helper with segmentation and pronunciation dictionary."""
+
+import re
+import subprocess
+import time
+from pathlib import Path
+from typing import List
+
+import yaml
+
+# Load configuration once
+_ROOT = Path(__file__).resolve().parents[1]
+_CFG_PATH = _ROOT / "config.yaml"
+_CFG: dict | None = None
+_HAS_ESPEAK: bool | None = None
+
+
+def _load_cfg() -> dict:
+    global _CFG
+    if _CFG is None:
+        try:
+            data = yaml.safe_load(_CFG_PATH.read_text(encoding="utf-8"))
+            _CFG = data.get("tts", {}) or {}
+        except Exception:
+            _CFG = {}
+    return _CFG
+
+
+def _espeak_available() -> bool:
+    global _HAS_ESPEAK
+    if _HAS_ESPEAK is None:
+        try:
+            subprocess.run(["espeak-ng", "--version"], check=False, capture_output=True)
+            _HAS_ESPEAK = True
+        except Exception:
+            _HAS_ESPEAK = False
+    return bool(_HAS_ESPEAK)
+
+
+# Pronunciation dictionary rules
+_REPLACEMENTS: List[tuple[re.Pattern[str], str | callable]] = [
+    (re.compile(r"(\d+)\s*GB"), lambda m: f"{m.group(1)} 기가바이트"),
+    (re.compile(r"(\d+)%"), lambda m: f"{m.group(1)} 퍼센트"),
+    (re.compile(r"°C"), lambda m: "도씨"),
+    (re.compile(r"\.pdf\b", re.IGNORECASE), lambda m: " 피디에프"),
+    (re.compile(r"\.zip\b", re.IGNORECASE), lambda m: " 집"),
+    (re.compile(r"\.png\b", re.IGNORECASE), lambda m: " 피앤지"),
+    (re.compile(r"\bURL\b"), lambda m: "유알엘"),
+    (re.compile(r"\bHTTP\b"), lambda m: "에이치티티피"),
+    (re.compile(r"\bCPU\b"), lambda m: "씨피유"),
+    (re.compile(r"\bGPU\b"), lambda m: "지피유"),
+    (re.compile(r"\bAI\b"), lambda m: "에이아이"),
+    (re.compile(r"\bLLM\b"), lambda m: "엘엘엠"),
+]
+
+
+def _apply_dict(text: str) -> str:
+    out = text
+    for pat, repl in _REPLACEMENTS:
+        out = pat.sub(repl, out)
+    return out
+
+
+def _segment(text: str) -> List[str]:
+    cfg = _load_cfg().get("espeak_ng", {})
+    # chunk_ms currently unused but reserved for future timing logic
+    # split by sentence-ending punctuation and optionally commas
+    parts: List[str] = []
+    for sent in re.split(r"(?<=[.!?])\s+", text):
+        sent = sent.strip()
+        if not sent:
+            continue
+        if sent.count(",") >= 2:
+            parts.extend(p.strip() for p in sent.split(",") if p.strip())
+        else:
+            parts.append(sent)
+    return parts
+
+
+def speak(text: str, lang: str = "ko") -> None:
+    """Speak ``text`` using eSpeak NG with config-driven parameters."""
+    if not _espeak_available():
+        return
+    cfg = _load_cfg()
+    ecfg = cfg.get("espeak_ng", {})
+    voices = ecfg.get("voices", {})
+    voice = voices.get(lang, voices.get("ko", "ko"))
+    rate = int(str(ecfg.get("rate", "+10")))
+    pitch = int(str(ecfg.get("pitch", 0)))
+    volume = int(str(ecfg.get("volume", 100)))
+    gap = int(str(ecfg.get("word_gap_ms", 20)))
+    buffer_ms = int(str(ecfg.get("buffer_ms", 300)))
+    speed = 175 + rate  # espeak default ~175 wpm
+    text = _apply_dict(text)
+    for seg in _segment(text):
+        cmd = [
+            "espeak-ng",
+            "-v",
+            voice,
+            "-s",
+            str(speed),
+            "-p",
+            str(pitch),
+            "-a",
+            str(volume),
+            "-g",
+            str(gap),
+            seg,
+        ]
+        subprocess.run(cmd, check=False)
+        time.sleep(buffer_ms / 1000.0)


### PR DESCRIPTION
## Summary
- configure TTS to use eSpeak NG with per-language voices and playback settings
- add shared eSpeak NG helper with segmentation and pronunciation rules
- route OCR Assist feedback through the shared eSpeak NG module

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement paddlepaddle>=2.5.1)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b25bd027348333add769930e25d1db