### PR TITLE
Ensure STT assist persists in accessibility mode

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -22,3 +22,5 @@
 - Assist mode now launches assist-specific STT and PaddleOCR modules via agent events, with periodic status logging and an /assist/status endpoint. Voice-command triggers and debug capture remain to be implemented.
 - STT Assist now reads a dedicated Assist-config via a batch script and runs faster-whisper small int8 on CPU. OCR Assist plays a "찍었습니다." TTS cue using eSpeak NG on CPU after capturing text.
 - Added eSpeak NG TTS configuration with pronunciation rules; OCR Assist now uses shared eSpeak module.
+- Overlay detects assist mode via the agent's /assist/status endpoint, loading Tool_memory_Assist.txt and limiting tools to stt_assist/ocr_assist while showing an "Assist mode" title. Config now defaults tool-calling and translation to local Qwen3 4B models. Voice command triggers and deeper assist features remain outstanding.
+- Assist mode now keeps STT assist alive until assist.off, ignoring stt.stop events and auto-restarting if the process exits. OCR watchdogs and wake-word triggers still need implementation.

--- a/Overlay/Tool_memory_Assist.txt
+++ b/Overlay/Tool_memory_Assist.txt
@@ -1,0 +1,17 @@
+You are a Tool Orchestrator. Respond ONLY with compact JSON:
+{"say":"...", "tool_calls":[{"name":"...","args":{...}}]}
+
+Assist mode rules:
+- Only call assist tools listed below.
+- No chain-of-thought; JSON ONLY.
+- Prefer short, actionable outputs.
+- If conversation is needed, respond in "say" without tool calls.
+
+Available assist tools:
+1) Start microphone transcription
+   -> {"name":"stt_assist.start","args":{}}
+   Stop when done -> {"name":"stt_assist.stop","args":{}}
+
+2) Screen OCR capture
+   -> {"name":"ocr_assist.start","args":{}}
+   Stop when done -> {"name":"ocr_assist.stop","args":{}}

--- a/config.yaml
+++ b/config.yaml
@@ -33,7 +33,7 @@ policy:
 translate:
   provider: "lmstudio"
   endpoint: "http://127.0.0.1:1234/v1"
-  model: "qwen/qwen3-8b-instruct"
+  model: "qwen/qwen3-4b-2507"
   api_key: ""
   max_refine_chars: 6500
   severity_threshold: 2
@@ -64,7 +64,7 @@ overlay:
   # 오버레이 앱 설정
   llm_tools:
     endpoint: "http://127.0.0.1:1234/v1"
-    model: "qwen/qwen3-4b-2507"
+    model: "qwen/qwen3-4b-thinking-2507"
     api_key: "lm-studio"
     timeout_seconds: 60
     max_new_tokens: 2000

--- a/tests/test_assist_persistence.py
+++ b/tests/test_assist_persistence.py
@@ -1,0 +1,88 @@
+import asyncio
+from types import SimpleNamespace
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import agent.server as server
+from agent.event_bus import EventBus
+from agent.schemas import Event
+
+
+class DummyProc:
+    def __init__(self):
+        self.dead = False
+
+    def poll(self):
+        return None if not self.dead else 0
+
+    def terminate(self):
+        self.dead = True
+
+
+def test_stt_stop_ignored(monkeypatch):
+    async def runner():
+        ctx = SimpleNamespace()
+        ctx.bus = EventBus()
+        ctx.config = {}
+        ctx.assist_mode = True
+
+        app = server.create_app(ctx)
+        async with app.router.lifespan_context(app):
+            stt_handler = None
+            for prefix, h in app.state._plugin_unsubs:
+                if prefix == "stt.":
+                    stt_handler = h
+                    break
+            app.state.stt_proc = DummyProc()
+            await stt_handler(Event(type="stt.stop", payload={}))
+            assert app.state.stt_proc is not None
+
+    try:
+        asyncio.run(runner())
+    except asyncio.CancelledError:
+        pass
+
+
+def test_ticker_restarts_stt(monkeypatch):
+    async def runner():
+        ctx = SimpleNamespace()
+        ctx.bus = EventBus()
+        ctx.config = {}
+        ctx.assist_mode = False
+
+        spawns = []
+
+        def dummy_spawn(cfg, key):
+            spawns.append(key)
+            return DummyProc()
+
+        monkeypatch.setattr(server, "_spawn_tool", dummy_spawn)
+
+        orig_sleep = asyncio.sleep
+
+        async def fast_sleep(_):
+            await orig_sleep(0)
+
+        monkeypatch.setattr(server.asyncio, "sleep", fast_sleep)
+
+        app = server.create_app(ctx)
+        async with app.router.lifespan_context(app):
+            assist_handler = None
+            for prefix, h in app.state._plugin_unsubs:
+                if prefix == "assist.":
+                    assist_handler = h
+                    break
+            await assist_handler(Event(type="assist.on", payload={}))
+            app.state.stt_proc.dead = True
+            await asyncio.sleep(0.01)
+            assert spawns.count("stt_assist.start") >= 2
+            await assist_handler(Event(type="assist.off", payload={}))
+
+    try:
+        asyncio.run(runner())
+    except asyncio.CancelledError:
+        pass
+


### PR DESCRIPTION
## Summary
- ignore stt.stop events while assist mode is active
- auto-restart stt_assist process if it exits during assist mode
- add tests for assist-mode STT persistence and update working memory

## Testing
- `pip install -r requirements.txt` *(fails: No matching distribution found for paddlepaddle>=2.5.1)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b26d2c71548333b197861699e37595