### PR TITLE
feat: add assist tools and dynamic models

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -25,3 +25,4 @@
 - Overlay detects assist mode via the agent's /assist/status endpoint, loading Tool_memory_Assist.txt and limiting tools to stt_assist/ocr_assist while showing an "Assist mode" title. Config now defaults tool-calling and translation to local Qwen3 4B models. Voice command triggers and deeper assist features remain outstanding.
 - Assist mode now keeps STT assist alive until assist.off, ignoring stt.stop events and auto-restarting if the process exits. OCR watchdogs and wake-word triggers still need implementation.
 - STT assist now detects configured voice commands and emits cmd.detected events; OCR/LLM orchestration and other assist features remain.
+- Overlay config and tool list now include STT/OCR Assist entries, auto-switching the tool-calling model between qwen/qwen3-4b-thinking-2507 and qwen/qwen3-4b-2507 based on assist mode, and showing "Luna Overlay v9 - Mode : Assist" when enabled.

--- a/Overlay/config_process_example.yaml
+++ b/Overlay/config_process_example.yaml
@@ -33,10 +33,35 @@ tools:
     args: ["D:/jip/home-agent/STT/main.py"]
     cwd: "D:/jip/home-agent/STT"
     no_console: true
-  stt.stop:
-    kind: "process_stop"
-    id: "stt"
-    method: "terminate"
+    stt.stop:
+      kind: "process_stop"
+      id: "stt"
+      method: "terminate"
+
+    stt_assist.start:
+      kind: "process"
+      id: "stt"
+      command: "D:/jip/home-agent/STT/assist_start.bat"
+      args: []
+      cwd: "D:/jip/home-agent/STT"
+      no_console: true
+      shell: true
+    stt_assist.stop:
+      kind: "process_stop"
+      id: "stt"
+      method: "terminate"
+
+    ocr_assist.start:
+      kind: "process"
+      id: "ocr"
+      command: "D:/jip/home-agent/.venv/Scripts/python.exe"
+      args: ["D:/jip/home-agent/OCR/OCR-Assist.py"]
+      cwd: "D:/jip/home-agent/OCR"
+      no_console: true
+    ocr_assist.stop:
+      kind: "process_stop"
+      id: "ocr"
+      method: "terminate"
 
 ui:
   opacity: 0.86

--- a/Overlay/overlay_app.py
+++ b/Overlay/overlay_app.py
@@ -312,7 +312,7 @@ MEMO_PATH_ASSIST = os.path.join(APP_DIR, "Tool_memory_Assist.txt")
 
 # ---------------- defaults ----------------
 DEFAULT_CFG = {
-    "llm_tools": {"endpoint": "http://127.0.0.1:1234/v1", "model": "qwen3-4b-instruct", "api_key": "", "timeout_seconds": 60},
+    "llm_tools": {"endpoint": "http://127.0.0.1:1234/v1", "model": "qwen/qwen3-4b-2507", "api_key": "", "timeout_seconds": 60},
     "llm_chat":  {"endpoint": "http://127.0.0.1:1234/v1", "model": "qwen3-14b-instruct", "api_key": "", "timeout_seconds": 60},
     "llm_vision": {"endpoint": "http://127.0.0.1:1234/v1", "model": "gemma-3-12b-it-qat", "api_key": "", "timeout_seconds": 60},
     "agent": {"health_url": "http://127.0.0.1:8765/health", "event_url": "http://127.0.0.1:8765/event", "health_interval_seconds": 2, "health_fail_quit_count": 3},
@@ -585,8 +585,14 @@ class Orchestrator:
 
         # detect assistive mode from agent server
         self.assist_mode = self._check_assist_mode()
+
+        cfg.setdefault("llm_tools", {})
+        cfg["llm_tools"]["model"] = (
+            "qwen/qwen3-4b-thinking-2507" if self.assist_mode else "qwen/qwen3-4b-2507"
+        )
+
         if self.assist_mode and self.window:
-            self.window.setWindowTitle("Luna Overlay (Assist mode)")
+            self.window.setWindowTitle("Luna Overlay v9 - Mode : Assist")
             if hasattr(self.window, "_update_title"):
                 self.window._update_title()
 

--- a/Overlay/plugins/tools/config/tools.yaml
+++ b/Overlay/plugins/tools/config/tools.yaml
@@ -46,3 +46,29 @@ tools:
           type: string
           description: "오디오 파일 경로"
       required: [audio_path]
+
+  - name: ocr_assist
+    module: Overlay.plugins.tools.tool.ocr
+    class: OCR
+    enabled: true
+    desc: "Assist OCR capture"
+    input_schema:
+      type: object
+      properties:
+        image_path:
+          type: string
+          description: "이미지 파일 경로"
+      required: [image_path]
+
+  - name: stt_assist
+    module: Overlay.plugins.tools.tool.stt
+    class: STT
+    enabled: true
+    desc: "Assist microphone transcription"
+    input_schema:
+      type: object
+      properties:
+        audio_path:
+          type: string
+          description: "오디오 파일 경로"
+      required: [audio_path]

--- a/tools/config/tools.yaml
+++ b/tools/config/tools.yaml
@@ -46,3 +46,29 @@ tools:
           type: string
           description: "오디오 파일 경로"
       required: [audio_path]
+
+  - name: ocr_assist
+    module: tools.tool.ocr
+    class: OCR
+    enabled: true
+    desc: "Assist OCR capture"
+    input_schema:
+      type: object
+      properties:
+        image_path:
+          type: string
+          description: "이미지 파일 경로"
+      required: [image_path]
+
+  - name: stt_assist
+    module: tools.tool.stt
+    class: STT
+    enabled: true
+    desc: "Assist microphone transcription"
+    input_schema:
+      type: object
+      properties:
+        audio_path:
+          type: string
+          description: "오디오 파일 경로"
+      required: [audio_path]


### PR DESCRIPTION
## Summary
- add STT/OCR Assist tool entries to overlay configs and registries
- switch tool-calling model based on assist mode with assist title
- filter plugin tools in assist mode

## Testing
- `pip install -r requirements.txt` *(fails: No matching distribution found for paddlepaddle>=2.5.1)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b277ee25008333ae89e909bdf7642a