### PR TITLE
Add microphone listening notifications

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -26,3 +26,7 @@
 - Assist mode now keeps STT assist alive until assist.off, ignoring stt.stop events and auto-restarting if the process exits. OCR watchdogs and wake-word triggers still need implementation.
 - STT assist now detects configured voice commands and emits cmd.detected events; OCR/LLM orchestration and other assist features remain.
 - Overlay config and tool list now include STT/OCR Assist entries, auto-switching the tool-calling model between qwen/qwen3-4b-thinking-2507 and qwen/qwen3-4b-2507 based on assist mode, and showing "Luna Overlay v9 - Mode : Assist" when enabled.
+- STT assist configuration refined: explicit sample rate, chunk size, and optional device name/index for reliable microphone selection. Added tests for device name matching.
+- OCR Assist now loads a detailed Assist-config for monitor selection, region cropping, and PaddleOCR options; full ROI capture and advanced OCR features still pending.
+- STT assist now issues toast notifications at start and again after 10 minutes to indicate microphone capture, and mixes all input channels so every microphone is heard. Wake-word triggers and privacy refinements remain.
+- Assist mode can now be toggled via `/assist on|off` or persisted through `config.yaml`'s `accessibility` flag; overlay broadcasts `assist.on/off` events and updates the config so agent and overlay launch in assist mode when enabled.

--- a/OCR/Assist-config.yaml
+++ b/OCR/Assist-config.yaml
@@ -1,0 +1,17 @@
+assist:
+  announce_text: "찍었습니다."
+
+capture:
+  monitor: 1        # 1-based monitor index
+  region: null      # optional [left, top, width, height]
+
+event:
+  url: http://127.0.0.1:8350/event
+  key: null
+
+ocr:
+  lang: korean
+  use_angle_cls: true
+  device: cpu
+  det_model_dir: null
+  rec_model_dir: null

--- a/OCR/OCR-Assist.py
+++ b/OCR/OCR-Assist.py
@@ -3,7 +3,13 @@ Captures the full screen and posts recognized text to the agent event bus."""
 from __future__ import annotations
 
 import os
-from typing import List
+
+import argparse
+from dataclasses import dataclass
+from typing import List, Optional
+
+import pathlib
+import yaml
 
 import numpy as np
 from PIL import Image
@@ -40,19 +46,77 @@ def _post_event(_type: str, _payload: dict, _prio: int = 5) -> None:
         pass
 
 
-def _capture_screen() -> Image.Image:
+@dataclass
+class OCRAssistConfig:
+    """Configuration for assistive OCR capture."""
+
+    monitor: int = 1  # 1-based monitor index
+    region: Optional[List[int]] = None  # [left, top, width, height]
+    lang: str = "korean"
+    use_angle_cls: bool = True
+    det_model_dir: Optional[str] = None
+    rec_model_dir: Optional[str] = None
+    device: str = "cpu"
+    announce_text: str = "찍었습니다."
+    event_url: Optional[str] = None
+    event_key: Optional[str] = None
+
+
+def load_config(path: str | None = None) -> OCRAssistConfig:
+    """Load OCR assist configuration from YAML."""
+
+    if path is None:
+        default = pathlib.Path(__file__).with_name("Assist-config.yaml")
+        path = str(default) if default.exists() else None
+
+    data: dict = {}
+    if path:
+        with open(path, "r", encoding="utf-8") as f:
+            raw = yaml.safe_load(f) or {}
+        cap = raw.get("capture") or {}
+        data["monitor"] = cap.get("monitor", 1)
+        data["region"] = cap.get("region")
+        ocr = raw.get("ocr") or {}
+        data.update(ocr)
+        assist = raw.get("assist") or {}
+        if "announce_text" in assist:
+            data["announce_text"] = assist["announce_text"]
+        event = raw.get("event") or {}
+        data["event_url"] = event.get("url")
+        data["event_key"] = event.get("key")
+    return OCRAssistConfig(**data)
+
+
+def _capture_screen(cfg: OCRAssistConfig) -> Image.Image:
     with mss() as sct:
-        shot = sct.grab(sct.monitors[1])
+        monitor = sct.monitors[cfg.monitor]
+        if cfg.region:
+            left, top, width, height = cfg.region
+            region = {
+                "left": monitor["left"] + left,
+                "top": monitor["top"] + top,
+                "width": width,
+                "height": height,
+            }
+            shot = sct.grab(region)
+        else:
+            shot = sct.grab(monitor)
         img = Image.frombytes("RGB", shot.size, shot.rgb)
         return img
 
 
-def _run_ocr(img: Image.Image) -> str:
+def _run_ocr(img: Image.Image, cfg: OCRAssistConfig) -> str:
     if PaddleOCR is None:
         raise RuntimeError("paddleocr is not installed")
-    ocr = PaddleOCR(use_angle_cls=True, lang="korean")
+    ocr = PaddleOCR(
+        use_angle_cls=cfg.use_angle_cls,
+        lang=cfg.lang,
+        det_model_dir=cfg.det_model_dir,
+        rec_model_dir=cfg.rec_model_dir,
+        device=cfg.device,
+    )
     np_img = np.array(img)
-    result = ocr.ocr(np_img, cls=True)
+    result = ocr.ocr(np_img, cls=cfg.use_angle_cls)
     lines: List[str] = []
     for line in result:
         for item in line:
@@ -60,14 +124,25 @@ def _run_ocr(img: Image.Image) -> str:
     return "\n".join(lines).strip()
 
 
-
 def main() -> None:
-    img = _capture_screen()
-    text = _run_ocr(img)
+    parser = argparse.ArgumentParser(description="Assistive screenshot OCR")
+    parser.add_argument("--config", help="Path to Assist-config.yaml", default=None)
+    args = parser.parse_args()
+
+    cfg = load_config(args.config)
+    global _EVENT_URL, _EVENT_KEY
+    if cfg.event_url:
+        _EVENT_URL = cfg.event_url
+    if cfg.event_key:
+        _EVENT_KEY = cfg.event_key
+
+    img = _capture_screen(cfg)
+    text = _run_ocr(img, cfg)
     if text:
         _post_event("ocr.text", {"text": text, "source": "paddle_assist"})
         print(text)
-        speak("찍었습니다.", lang="ko")
+        if cfg.announce_text:
+            speak(cfg.announce_text, lang="ko")
 
 
 if __name__ == "__main__":  # pragma: no cover - manual execution

--- a/Overlay/overlay_app.py
+++ b/Overlay/overlay_app.py
@@ -387,6 +387,21 @@ def read_tool_memory(assist_mode: bool = False) -> str:
     except Exception:
         return ""
 
+
+def save_accessibility(enabled: bool) -> None:
+    """Persist accessibility flag to the root config.yaml."""
+    try:
+        if ROOT_CFG_PATH.exists():
+            with open(ROOT_CFG_PATH, "r", encoding="utf-8") as f:
+                data = yaml.safe_load(f) or {}
+        else:
+            data = {}
+        data["accessibility"] = 1 if enabled else 0
+        with open(ROOT_CFG_PATH, "w", encoding="utf-8") as f:
+            yaml.safe_dump(data, f, allow_unicode=True, sort_keys=False)
+    except Exception as e:
+        logger.warning(f"[assist] failed to persist accessibility: {e}")
+
 # ---------------- utils ----------------
 
 
@@ -583,8 +598,10 @@ class Orchestrator:
         self.cfg = cfg
         self.window = window  # OverlayWindow 참조
 
-        # detect assistive mode from agent server
-        self.assist_mode = self._check_assist_mode()
+        # determine assist mode from config or agent server
+        server_assist = self._check_assist_mode()
+        cfg_assist = bool(cfg.get("accessibility"))
+        self.assist_mode = cfg_assist or server_assist
 
         cfg.setdefault("llm_tools", {})
         cfg["llm_tools"]["model"] = (
@@ -621,17 +638,28 @@ class Orchestrator:
         tools_map.setdefault('stt_assist.stop',  te['stt']['event_url'])
         tools_map.setdefault('ocr_assist.start', te['ocr']['event_url'])
         tools_map.setdefault('ocr_assist.stop',  te['ocr']['event_url'])
+        tools_map.setdefault('assist.on', te['stt']['event_url'])
+        tools_map.setdefault('assist.off', te['stt']['event_url'])
         te.setdefault('web', {'event_url': 'http://127.0.0.1:8765/event'})
         tools_map.setdefault('web.search', te['web']['event_url'])
         te.setdefault('discord', {'event_url': 'http://127.0.0.1:8765/event'})
         tools_map.setdefault('discord.collect.start', te['discord']['event_url'])
         tools_map.setdefault('discord.collect.stop',  te['discord']['event_url'])
 
+        self._all_tools_map = dict(tools_map)
+        if cfg_assist and not server_assist:
+            threading.Thread(
+                target=lambda: asyncio.run(
+                    self.run_tool_calls([{ "name": "assist.on", "args": {} }])
+                ),
+                daemon=True,
+            ).start()
+
         if self.assist_mode:
             allowed = {
                 k: v
                 for k, v in tools_map.items()
-                if k.startswith('stt_assist') or k.startswith('ocr_assist')
+                if k.startswith('stt_assist') or k.startswith('ocr_assist') or k.startswith('assist.')
             }
             self.cfg['tools'] = allowed
             self.tool_handlers = {k: v for k, v in TOOL_HANDLERS.items() if k in allowed}
@@ -683,6 +711,28 @@ class Orchestrator:
                     tmap['stt.stop'] = tmap.get('stt.start') or tmap.get('stt')
         except Exception as e:
             logger.warning(f"[tools] alias mapping failed: {e}")
+
+    def set_assist_mode(self, enabled: bool):
+        """Toggle assist mode at runtime."""
+        self.assist_mode = bool(enabled)
+        self.cfg["accessibility"] = 1 if enabled else 0
+        if enabled:
+            allowed = {
+                k: v
+                for k, v in self._all_tools_map.items()
+                if k.startswith('stt_assist') or k.startswith('ocr_assist') or k.startswith('assist.')
+            }
+            self.cfg['tools'] = allowed
+            self.tool_handlers = {k: v for k, v in TOOL_HANDLERS.items() if k in allowed}
+        else:
+            self.cfg['tools'] = dict(self._all_tools_map)
+            self.tool_handlers = TOOL_HANDLERS
+        self.reload_memory()
+        if self.window:
+            title = "Luna Overlay v9 - Mode : Assist" if enabled else "Luna Overlay v9"
+            self.window.setWindowTitle(title)
+            if hasattr(self.window, "_update_title"):
+                self.window._update_title()
 
     def orchestrate(self, user_text: str) -> Dict[str, Any]:
         """
@@ -1962,11 +2012,15 @@ class OverlayWindow(QtWidgets.QWidget):
                 return True
             state = toks[1].lower() if len(toks) >= 2 else "on"
             if state in ("on", "1", "true"):
-                self.orch.cfg["accessibility"] = 1
+                self.orch.set_assist_mode(True)
+                save_accessibility(True)
+                self._run_tool_calls_async([{ "name": "assist.on", "args": {} }])
                 self._append("overlay", "Accessibility mode enabled")
                 logger.info("[assist] enabled")
             elif state in ("off", "0", "false"):
-                self.orch.cfg["accessibility"] = 0
+                self.orch.set_assist_mode(False)
+                save_accessibility(False)
+                self._run_tool_calls_async([{ "name": "assist.off", "args": {} }])
                 self._append("overlay", "Accessibility mode disabled")
                 logger.info("[assist] disabled")
             else:

--- a/STT/Assist-config.yaml
+++ b/STT/Assist-config.yaml
@@ -15,6 +15,10 @@ stt:
   compute_type: int8     # CPU friendly
   language: auto         # auto-detect ko/en/ja/zh
   vad: silero            # or webrtcvad
+  sample_rate: 16000     # Hz
+  block_ms: 3000         # audio chunk in milliseconds
+  device_index: null     # set to an int to force a specific device
+  device_name: null      # optional substring match for device name
   chunk_sec: 7
   chunk_overlap_sec: 0.5
   beam_size: 3

--- a/STT/assist.py
+++ b/STT/assist.py
@@ -86,6 +86,27 @@ def _post_event(_type: str, _payload: dict, _prio: int = 5) -> None:
         pass
 
 
+def _notify_listening() -> None:
+    """Toast notification that STT Assist is listening."""
+    msg = "마이크 청취 중"
+    _post_event("overlay.toast", {"title": "STT", "text": msg})
+    try:
+        from agent.sinks import toast_notify
+
+        toast_notify("STT", msg)
+    except Exception:
+        pass
+
+
+def _mix_channels(pcm: bytes, channels: int) -> bytes:
+    """Mix multi-channel PCM16 to mono."""
+    if channels <= 1:
+        return bytes(pcm)
+    data = np.frombuffer(pcm, dtype=np.int16)
+    data = data.reshape(-1, channels).mean(axis=1).astype(np.int16)
+    return data.tobytes()
+
+
 @dataclass
 class AssistConfig:
     """Configuration for assistive STT."""
@@ -105,6 +126,7 @@ class AssistConfig:
     sample_rate: int = 16_000
     block_ms: int = 3_000  # transcribe every N milliseconds
     device_index: Optional[int] = None
+    device_name: Optional[str] = None
     commands: Dict[str, List[str]] = field(
         default_factory=lambda: {
             "capture": ["캡쳐", "캡처", "capture", "スクショ", "截图", "截屏"],
@@ -221,12 +243,23 @@ class SubtitleUI:
                 pass
 
 
-def _select_input_device(device_index: Optional[int]) -> Optional[int]:
+def _select_input_device(
+    device_index: Optional[int], device_name: Optional[str]
+) -> Optional[int]:
     """Return a microphone device index, auto-detecting when unspecified."""
     if device_index is not None:
         return device_index
     if sd is None:
         return None
+    try:
+        if device_name:
+            devices = sd.query_devices()  # pragma: no cover - environment dependent
+            for i, dev in enumerate(devices):
+                name = str(dev.get("name", "")).lower()
+                if device_name.lower() in name and dev.get("max_input_channels", 0) > 0:
+                    return i
+    except Exception:
+        pass
     try:
         default = sd.default.device  # type: ignore[attr-defined]
         if isinstance(default, (tuple, list)):
@@ -258,11 +291,17 @@ def run(cfg: AssistConfig) -> None:
 
     q: "queue.Queue[bytes]" = queue.Queue()
 
+    device = _select_input_device(cfg.device_index, cfg.device_name)
+    try:
+        dev_info = sd.query_devices(device)  # pragma: no cover - environment dependent
+        channels = int(dev_info.get("max_input_channels", 1)) or 1
+    except Exception:  # pragma: no cover - environment dependent
+        channels = 1
+
     def callback(indata, frames, time, status):  # pragma: no cover - realtime
-        q.put(bytes(indata))
+        q.put(_mix_channels(bytes(indata), channels))
 
     blocksize = int(cfg.sample_rate * (cfg.block_ms / 1000))
-    device = _select_input_device(cfg.device_index)
 
     def worker():  # pragma: no cover - realtime loop
         buf = bytearray()
@@ -277,10 +316,12 @@ def run(cfg: AssistConfig) -> None:
         samplerate=cfg.sample_rate,
         blocksize=blocksize,
         dtype="int16",
-        channels=1,
+        channels=channels,
         callback=callback,
         device=device,
     ):
+        _notify_listening()
+        threading.Timer(600, _notify_listening).start()
         threading.Thread(target=worker, daemon=True).start()
         ui.loop()
 

--- a/tests/test_assist.py
+++ b/tests/test_assist.py
@@ -14,7 +14,23 @@ AssistConfig = assist.AssistConfig
 
 
 def test_select_device_passthrough():
-    assert assist._select_input_device(3) == 3
+    assert assist._select_input_device(3, None) == 3
+
+
+def test_select_device_by_name(monkeypatch):
+    class DummySD:
+        def __init__(self):
+            self.default = type("D", (), {"device": (None, None)})
+
+        def query_devices(self):
+            return [
+                {"name": "NoMic", "max_input_channels": 0},
+                {"name": "Mic B", "max_input_channels": 2},
+            ]
+
+    dummy = DummySD()
+    monkeypatch.setattr(assist, "sd", dummy)
+    assert assist._select_input_device(None, "mic b") == 1
 
 
 def test_select_device_auto(monkeypatch):
@@ -24,13 +40,13 @@ def test_select_device_auto(monkeypatch):
 
         def query_devices(self):
             return [
-                {"max_input_channels": 0},
-                {"max_input_channels": 2},
+                {"name": "NoMic", "max_input_channels": 0},
+                {"name": "Mic B", "max_input_channels": 2},
             ]
 
     dummy = DummySD()
     monkeypatch.setattr(assist, "sd", dummy)
-    assert assist._select_input_device(None) == 1
+    assert assist._select_input_device(None, None) == 1
 
 
 class DummyModel:
@@ -67,3 +83,37 @@ def test_transcriber_posts_event():
             5,
         )
     ]
+
+
+def test_mix_channels_stereo_to_mono():
+    left = np.array([0, 1000, -1000], dtype=np.int16)
+    right = np.array([1000, -1000, 0], dtype=np.int16)
+    interleaved = np.column_stack((left, right)).ravel().tobytes()
+    mono = assist._mix_channels(interleaved, 2)
+    out = np.frombuffer(mono, dtype=np.int16)
+    expected = np.array([(0 + 1000) / 2, (1000 - 1000) / 2, (-1000 + 0) / 2], dtype=np.int16)
+    assert np.array_equal(out, expected)
+
+
+def test_notify_listening(monkeypatch):
+    events = []
+
+    def fake_post(evt_type, payload, prio=5):
+        events.append((evt_type, payload, prio))
+
+    called = {}
+
+    def fake_toast(title, msg):
+        called[(title, msg)] = True
+    import types, sys
+
+    monkeypatch.setattr(assist, "_post_event", fake_post)
+    pkg = types.ModuleType("agent")
+    sinks = types.ModuleType("agent.sinks")
+    sinks.toast_notify = fake_toast
+    pkg.sinks = sinks
+    sys.modules["agent"] = pkg
+    sys.modules["agent.sinks"] = sinks
+    assist._notify_listening()
+    assert events == [("overlay.toast", {"title": "STT", "text": "마이크 청취 중"}, 5)]
+    assert ("STT", "마이크 청취 중") in called

--- a/tests/test_ocr_assist.py
+++ b/tests/test_ocr_assist.py
@@ -1,0 +1,58 @@
+import importlib.util
+from pathlib import Path
+from PIL import Image
+import numpy as np
+import sys
+
+spec = importlib.util.spec_from_file_location(
+    "ocr_assist", Path(__file__).resolve().parents[1] / "OCR" / "OCR-Assist.py"
+)
+ocr_assist = importlib.util.module_from_spec(spec)
+sys.modules["ocr_assist"] = ocr_assist
+spec.loader.exec_module(ocr_assist)
+OCRAssistConfig = ocr_assist.OCRAssistConfig
+load_config = ocr_assist.load_config
+
+
+def test_load_config_values(tmp_path):
+    cfg_file = tmp_path / "Assist-config.yaml"
+    cfg_file.write_text(
+        """
+assist:
+  announce_text: done
+capture:
+  monitor: 2
+  region: [10, 20, 30, 40]
+ocr:
+  lang: en
+  use_angle_cls: false
+  device: gpu
+""",
+        encoding="utf-8",
+    )
+    cfg = load_config(str(cfg_file))
+    assert cfg.monitor == 2
+    assert cfg.region == [10, 20, 30, 40]
+    assert cfg.lang == "en"
+    assert cfg.use_angle_cls is False
+    assert cfg.device == "gpu"
+    assert cfg.announce_text == "done"
+
+
+def test_run_ocr_uses_config(monkeypatch):
+    calls = {}
+
+    class DummyOCR:
+        def __init__(self, **kwargs):
+            calls.update(kwargs)
+
+        def ocr(self, img, cls=True):
+            return [[(None, ("ok", 0.9))]]
+
+    monkeypatch.setattr(ocr_assist, "PaddleOCR", DummyOCR)
+    img = Image.fromarray(np.zeros((1, 1, 3), dtype=np.uint8))
+    cfg = OCRAssistConfig(lang="en", use_angle_cls=False, device="cpu")
+    text = ocr_assist._run_ocr(img, cfg)
+    assert calls["lang"] == "en"
+    assert calls["use_angle_cls"] is False
+    assert text == "ok"


### PR DESCRIPTION
## Summary
- persist accessibility flag in config and allow `/assist on|off` to toggle it
- orchestrator checks config or server to enter assist mode and broadcasts `assist.on/off`
- update working notes with assist-mode persistence reminder

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement paddlepaddle>=2.5.1)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b379d158e88333ade85d989a4e6c4a