### PR TITLE
Switch accessibility mode to jan-nano

### DIFF
--- a/Overlay/config.yaml
+++ b/Overlay/config.yaml
@@ -1,9 +1,9 @@
 llm_tools:    # 4B (빠른 플래너)
   endpoint: "http://127.0.0.1:1234/v1"
-  model: "qwen/qwen3-4b-2507"
+  model: "jan/jan-nano"
   api_key: "lm-studio"
   timeout_seconds: 60
-  max_new_tokens: 2000
+  max_new_tokens: 4096
   temperature: 0.0
 
 llm_chat:     # 14B (기본 채팅)
@@ -131,7 +131,8 @@ llm:
 
 llm_tools_small:
   endpoint: "http://127.0.0.1:11434/v1"
-  model: "qwen/qwen3-4b-2507"
+  model: "jan/jan-nano"
+  max_new_tokens: 4096
 
 llm_tools_chat:
   endpoint: "http://127.0.0.1:11434/v1"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 📦 필요 모델 목록
 Qwen2.5-VL-7B (고속 OCR+한국어 번역)
-Qwen3 2507 4B
+jan-nano
 Qwen3 8B
 
 
@@ -47,8 +47,8 @@ Whisper Faster는 STT 실행시 설치됩니다. 받는데 시간이 걸릴 수 
 ## ⚙️ 동작 구조
 
 ### 기본 오케스트레이션
-- **Qwen3 2507 4B**  
-  → Overlay의 대부분 기능(툴 호출 담당)  
+- **jan-nano**
+  → Overlay의 대부분 기능(툴 호출 담당)
 
 ### OCR 파이프라인
 - **LM Studio**에서 4B 종료 후:
@@ -63,7 +63,7 @@ Whisper Faster는 STT 실행시 설치됩니다. 받는데 시간이 걸릴 수 
 
 ### STT 파이프라인
 - `Whisper Tiny / Faster` : 음성 전사 (BBC 뉴스도 인식 가능)
-- `Qwen3-2507-4B` : 전사 결과물 한국어 번역
+- `jan-nano` : 전사 결과물 한국어 번역
 - 결과는 Overlay 및 `VSRG-Ts-to-KR.py (STT)` 창에 표시, **화자 분리 지원**
 
 ### 오케스트레이션 순환
@@ -84,7 +84,7 @@ Whisper Faster는 STT 실행시 설치됩니다. 받는데 시간이 걸릴 수 
 
 ## 📦 필요 모델 목록
 - **Qwen2.5-VL-7B**
-- **Qwen3 2507 4B**
+- **jan-nano**
 - **Qwen3 8B**
 - **GPT-OSS-20B** (선택적)
 - **Qwen3 14B** (선택적)

--- a/docs/TRANSLATION_VRAM_POLICY.md
+++ b/docs/TRANSLATION_VRAM_POLICY.md
@@ -3,7 +3,7 @@
 방향 규칙 (전부 LLM만 사용)
 
 KO → X(EN/JA/ZH …): LLM 체인 사용
-1순위 qwen/qwen3-4b-2507 → 실패/부족 시 hyperclovax-seed-text-instruct-1.5b
+1순위 jan/jan-nano → 실패/부족 시 hyperclovax-seed-text-instruct-1.5b
 
 X → KO: LLM만 사용(동일 체인: Qwen4B → HyperCLOVA 1.5B)
 
@@ -29,14 +29,14 @@ VRAM 정책 (LLM 전용)
 
 언로드: 가장 크고 최근 사용 빈도 낮은 모델부터 제거(LRU, 쿨다운 30–60s)
 
-강등: qwen/qwen3-4b-2507 → hyperclovax-seed-text-instruct-1.5b
+강등: jan/jan-nano → hyperclovax-seed-text-instruct-1.5b
 
 그래도 초과/실패 시: 대기(큐잉) 또는 CPU/외부 API 임시 폴백(옵션)
 
 큐잉/스로틀: 번역 요청 큐 최대 3건, 대기 2s↑면 경량 모델 우선
 
 참고용 예상치(환경에 따라 조정):
-Qwen3 4B(INT4) ≈ 4.5GB / HyperCLOVA-X Seed 1.5B ≈ 2.2GB
+jan-nano (INT4) ≈ 4.5GB / HyperCLOVA-X Seed 1.5B ≈ 2.2GB
 
 클립보드 & 알림
 
@@ -57,7 +57,7 @@ translation:
   default_target: en
   engine: llm                         # 전 방향 LLM만 사용
   llm_endpoint: http://127.0.0.1:1234/v1
-  llm_model_primary:  "qwen/qwen3-4b-2507"
+  llm_model_primary:  "jan/jan-nano"
   llm_model_fallback: "hyperclovax-seed-text-instruct-1.5b"
 
 clipboard:
@@ -71,11 +71,11 @@ scheduler:
   vram_soft_cap_ratio: 0.90
   max_loaded_models: 2
   fallbacks:
-    - { from: "qwen/qwen3-4b-2507", to: "hyperclovax-seed-text-instruct-1.5b" }
+    - { from: "jan/jan-nano", to: "hyperclovax-seed-text-instruct-1.5b" }
 
 models:
   metadata:
-    qwen/qwen3-4b-2507:                  { vram_mib_est: 4500 }
+    jan/jan-nano:                         { vram_mib_est: 4500 }
     hyperclovax-seed-text-instruct-1.5b: { vram_mib_est: 2200 }
 
 처리 흐름 (9단계)


### PR DESCRIPTION
## Summary
- use jan-nano model for fast planning and tool tasks
- document jan-nano as the default model for accessibility mode
- update translation VRAM policy to reference jan-nano
- raise jan-nano max token limit to 4096

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b393a23bcc8333acbc098e058e46c6