### PR TITLE
Add toast notifications and Jan Nano refinement for OCR assist

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -35,3 +35,6 @@
 - STT assist now warns when downloading Whisper model, keeps subtitle window topmost with larger text, filters silence/'You', and batch script notes model download may be slow. Further wake-word controls and overlay polish remain.
 - STT assist now warns to install faster-whisper if missing, telling users to run 'pip install faster-whisper'; full STT integration remains.
 - requirements.txt now marks faster-whisper as required for live STT and the assist script mentions installing via the requirements file.
+- STT assist resamples incoming audio to the configured sample rate so external sources with different bitrates are handled. Full wake-word control and broader assist features still pending.
+- OCR assist now issues toast notifications when capturing and during OCR, and can refine EasyOCR output via a Jan Nano endpoint. Proper endpoint configuration and deeper Jan-based post-processing remain.
+- Jan Nano refinement now uses LM Studio or Ollama endpoints to run jan-nano.

--- a/OCR/OCR-Assist.py
+++ b/OCR/OCR-Assist.py
@@ -46,6 +46,61 @@ def _post_event(_type: str, _payload: dict, _prio: int = 5) -> None:
         pass
 
 
+def _notify(msg: str) -> None:
+    """Display a toast notification locally and via overlay."""
+    _post_event("overlay.toast", {"title": "OCR", "text": msg})
+    try:
+        from agent.sinks import toast_notify
+
+        toast_notify("OCR", msg)
+    except Exception:
+        pass
+
+
+def _refine_with_jan(text: str) -> str:
+    """Send OCR text to a jan-nano model served by LM Studio or Ollama."""
+    endpoint = (
+        os.environ.get("JAN_ENDPOINT")
+        or os.environ.get("LM_STUDIO_ENDPOINT")
+        or os.environ.get("OLLAMA_ENDPOINT")
+    )
+    if not endpoint or not text:
+        return text
+    model = (
+        os.environ.get("JAN_MODEL")
+        or os.environ.get("LM_STUDIO_MODEL")
+        or os.environ.get("OLLAMA_MODEL")
+        or "jan-nano"
+    )
+    api_key = (
+        os.environ.get("JAN_API_KEY")
+        or os.environ.get("LM_STUDIO_API_KEY")
+        or os.environ.get("OLLAMA_API_KEY")
+        or ""
+    )
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    payload = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": "Refine OCR output."},
+            {"role": "user", "content": text},
+        ],
+        "temperature": 0.2,
+        "reasoning": {"effort": "high"},
+    }
+    try:
+        r = requests.post(
+            f"{endpoint}/chat/completions", headers=headers, json=payload, timeout=10
+        )
+        r.raise_for_status()
+        data = r.json()
+        return (data["choices"][0]["message"]["content"] or "").strip() or text
+    except Exception:
+        return text
+
+
 @dataclass
 class OCRAssistConfig:
     """Configuration for assistive OCR capture."""
@@ -125,7 +180,10 @@ def main() -> None:
         _EVENT_KEY = cfg.event_key
 
     img = _capture_screen(cfg)
+    _notify("방금 OCR 어시스트가 캡쳐했어요.")
+    _notify("OCR진행 중입니다.")
     text = _run_ocr(img, cfg)
+    text = _refine_with_jan(text)
     if text:
         _post_event("ocr.text", {"text": text, "source": "easyocr_assist"})
         print(text)

--- a/STT/README.md
+++ b/STT/README.md
@@ -65,4 +65,6 @@ python assist.py --model tiny.en
 The script auto-selects the system microphone when no device is specified, so
 most users can simply run it without flags. Pass `--device-index` only to pin a
 specific input. It is intentionally lightweight and can be started automatically
-when 보조모드(accessibility mode) is enabled.
+when 보조모드(accessibility mode) is enabled. Incoming audio with a different
+sample rate is automatically resampled to match the configured rate so external
+sources remain compatible.

--- a/STT/assist.py
+++ b/STT/assist.py
@@ -23,6 +23,7 @@ import queue
 import os
 import threading
 import time
+from math import gcd
 from typing import Callable, Dict, List, Optional
 import yaml
 
@@ -107,6 +108,23 @@ def _mix_channels(pcm: bytes, channels: int) -> bytes:
     return data.tobytes()
 
 
+def _resample_pcm16(pcm: bytes, src_rate: int, dst_rate: int) -> bytes:
+    """Resample mono PCM16 audio to the desired sample rate."""
+    if src_rate == dst_rate:
+        return bytes(pcm)
+    try:
+        from scipy.signal import resample_poly
+    except Exception:  # pragma: no cover - optional dependency
+        raise RuntimeError("scipy is required for resampling")
+    data = np.frombuffer(pcm, dtype=np.int16).astype(np.float32)
+    g = gcd(src_rate, dst_rate)
+    up = dst_rate // g
+    down = src_rate // g
+    resampled = resample_poly(data, up, down)
+    resampled = np.clip(resampled, -32768, 32767).astype(np.int16)
+    return resampled.tobytes()
+
+
 @dataclass
 class AssistConfig:
     """Configuration for assistive STT."""
@@ -157,8 +175,14 @@ class AssistTranscriber:
         self.cfg = config or AssistConfig()
         self.ui = ui
 
-    def transcribe(self, pcm16: bytes) -> str:
-        """Transcribe a chunk of PCM16 mono audio."""
+    def transcribe(self, pcm16: bytes, sample_rate: int | None = None) -> str:
+        """Transcribe a chunk of PCM16 mono audio.
+
+        If ``sample_rate`` is provided and differs from ``cfg.sample_rate`` the
+        audio is resampled so Whisper receives the expected rate.
+        """
+        if sample_rate and sample_rate != self.cfg.sample_rate:
+            pcm16 = _resample_pcm16(pcm16, sample_rate, self.cfg.sample_rate)
         raw = np.frombuffer(pcm16, dtype=np.int16)
         if np.abs(raw).mean() < 100:
             return ""

--- a/tests/test_assist.py
+++ b/tests/test_assist.py
@@ -149,3 +149,31 @@ def test_transcriber_filters_you():
     text = transcriber.transcribe(pcm)
     assert text == ""
     assert events == []
+
+
+def test_resample_pcm16_length():
+    pcm = np.arange(8000, dtype=np.int16).tobytes()
+    out = assist._resample_pcm16(pcm, 8000, 16_000)
+    assert len(out) == 16_000 * 2
+
+
+class LenModel:
+    def __init__(self):
+        self.model_size = "dummy"
+        self.last_len = None
+
+    def transcribe(self, audio, language="en"):
+        self.last_len = len(audio)
+        class Seg:
+            text = "hi"
+        return [Seg()], None
+
+
+def test_transcriber_resamples(monkeypatch):
+    model = LenModel()
+    cfg = AssistConfig()
+    transcriber = AssistTranscriber(model, lambda *args: None, cfg)
+    pcm = (np.full(8000, 5000, dtype=np.int16)).tobytes()
+    text = transcriber.transcribe(pcm, sample_rate=8000)
+    assert text == "hi"
+    assert model.last_len == cfg.sample_rate

--- a/tests/test_ocr_assist.py
+++ b/tests/test_ocr_assist.py
@@ -55,3 +55,24 @@ def test_run_ocr_uses_config(monkeypatch):
     assert calls["langs"] == ["en"]
     assert calls["gpu"] is False
     assert text == "ok"
+
+
+def test_refine_with_jan_supports_lmstudio(monkeypatch):
+    called = {}
+
+    class DummyResp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"choices": [{"message": {"content": "refined"}}]}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        called["url"] = url
+        return DummyResp()
+
+    monkeypatch.setenv("LM_STUDIO_ENDPOINT", "http://lmstudio:1234/v1")
+    monkeypatch.setattr(ocr_assist.requests, "post", fake_post)
+    out = ocr_assist._refine_with_jan("hi")
+    assert called["url"] == "http://lmstudio:1234/v1/chat/completions"
+    assert out == "refined"


### PR DESCRIPTION
## Summary
- Notify users with toasts when OCR assist captures the screen and begins recognition
- Refine EasyOCR output through a jan-nano model served by LM Studio or Ollama before posting results
- Log new refinement capability in agent memory

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement torch>=2.1.0)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3ce5262b083338bdf0bd8b4b7c85a