### PR TITLE
Launch STT assist via Python and keyword-gate LLM

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -38,3 +38,4 @@
 - STT assist resamples incoming audio to the configured sample rate so external sources with different bitrates are handled. Full wake-word control and broader assist features still pending.
 - OCR assist now issues toast notifications when capturing and during OCR, and can refine EasyOCR output via a Jan Nano endpoint. Proper endpoint configuration and deeper Jan-based post-processing remain.
 - Jan Nano refinement now uses LM Studio or Ollama endpoints to run jan-nano.
+- STT assist is launched directly via python, shows transcriptions in the overlay, and only forwards STT text to the LLM when the wake keyword "루나" is spoken. Both assist and normal modes now use qwen/qwen3-4b-2507 and filter tools accordingly.

--- a/Overlay/agent/plugins/translator_plugin.py
+++ b/Overlay/agent/plugins/translator_plugin.py
@@ -101,6 +101,11 @@ class TranslatorPlugin(BasePlugin):
         if not text and not existing:
             return
 
+        if event.type == "stt.text" and payload.get("source") == "assist":
+            kw = self.ctx.config.get("stt", {}).get("llm_keyword")
+            if kw and kw not in text:
+                return
+
         translated = existing
         if not translated:
             try:

--- a/Overlay/config_process_example.yaml
+++ b/Overlay/config_process_example.yaml
@@ -41,11 +41,10 @@ tools:
     stt_assist.start:
       kind: "process"
       id: "stt"
-      command: "D:/jip/home-agent/STT/assist_start.bat"
-      args: []
+      command: "D:/jip/home-agent/.venv/Scripts/python.exe"
+      args: ["D:/jip/home-agent/STT/assist.py", "--config", "D:/jip/home-agent/STT/Assist-config.yaml"]
       cwd: "D:/jip/home-agent/STT"
       no_console: true
-      shell: true
     stt_assist.stop:
       kind: "process_stop"
       id: "stt"

--- a/Overlay/overlay_app.py
+++ b/Overlay/overlay_app.py
@@ -604,9 +604,7 @@ class Orchestrator:
         self.assist_mode = cfg_assist or server_assist
 
         cfg.setdefault("llm_tools", {})
-        cfg["llm_tools"]["model"] = (
-            "qwen/qwen3-4b-thinking-2507" if self.assist_mode else "qwen/qwen3-4b-2507"
-        )
+        cfg["llm_tools"]["model"] = "qwen/qwen3-4b-2507"
 
         if self.assist_mode and self.window:
             self.window.setWindowTitle("Luna Overlay v9 - Mode : Assist")
@@ -664,7 +662,13 @@ class Orchestrator:
             self.cfg['tools'] = allowed
             self.tool_handlers = {k: v for k, v in TOOL_HANDLERS.items() if k in allowed}
         else:
-            self.tool_handlers = TOOL_HANDLERS
+            allowed = {
+                k: v
+                for k, v in tools_map.items()
+                if not (k.startswith('stt_assist') or k.startswith('ocr_assist') or k.startswith('assist.'))
+            }
+            self.cfg['tools'] = allowed
+            self.tool_handlers = {k: v for k, v in TOOL_HANDLERS.items() if k in allowed}
 
     def _check_assist_mode(self) -> bool:
         try:

--- a/Overlay/overlay_app_enhanced.py
+++ b/Overlay/overlay_app_enhanced.py
@@ -677,7 +677,7 @@ def create_enhanced_config():
     config = {
         "llm_tools": {
             "endpoint": "http://127.0.0.1:1234/v1",
-            "model": "qwen3-4b-instruct",
+            "model": "qwen/qwen3-4b-2507",
             "api_key": "",
             "timeout_seconds": 60
         },

--- a/Overlay/overlay_plugin_system.py
+++ b/Overlay/overlay_plugin_system.py
@@ -547,15 +547,28 @@ class PluginAwareOrchestrator:
         self.assist_mode = self._check_assist_mode(config)
 
         config.setdefault("llm_tools", {})
-        config["llm_tools"]["model"] = (
-            "qwen/qwen3-4b-thinking-2507" if self.assist_mode else "qwen/qwen3-4b-2507"
-        )
+        config["llm_tools"]["model"] = "qwen/qwen3-4b-2507"
 
         if self.assist_mode:
             allowed = [
                 name
                 for name in self.plugin_manager.handlers.keys()
-                if name.startswith("stt_assist") or name.startswith("ocr_assist")
+                if name.startswith("stt_assist") or name.startswith("ocr_assist") or name.startswith("assist.")
+            ]
+            self.plugin_manager.handlers = {
+                k: v for k, v in self.plugin_manager.handlers.items() if k in allowed
+            }
+            self.plugin_manager.tools_schema = [
+                s
+                for s in self.plugin_manager.tools_schema
+                if s.get("function", {}).get("name") in allowed
+            ]
+        else:
+            disallowed = ("stt_assist", "ocr_assist", "assist.")
+            allowed = [
+                name
+                for name in self.plugin_manager.handlers.keys()
+                if not name.startswith(disallowed)
             ]
             self.plugin_manager.handlers = {
                 k: v for k, v in self.plugin_manager.handlers.items() if k in allowed

--- a/config.yaml
+++ b/config.yaml
@@ -64,7 +64,7 @@ overlay:
   # 오버레이 앱 설정
   llm_tools:
     endpoint: "http://127.0.0.1:1234/v1"
-    model: "qwen/qwen3-4b-thinking-2507"
+    model: "qwen/qwen3-4b-2507"
     api_key: "lm-studio"
     timeout_seconds: 60
     max_new_tokens: 2000
@@ -151,11 +151,10 @@ overlay:
     stt_assist.start:
       kind: "process"
       id: "stt"
-      command: "D:/jip/home-agent/STT/assist_start.bat"
-      args: []
+      command: "D:/jip/home-agent/.venv/Scripts/python.exe"
+      args: ["D:/jip/home-agent/STT/assist.py", "--config", "D:/jip/home-agent/STT/Assist-config.yaml"]
       cwd: "D:/jip/home-agent/STT"
       no_console: true
-      shell: true
       env:
         AGENT_EVENT_URL: "http://127.0.0.1:8350/event"
     stt_assist.stop:
@@ -248,6 +247,7 @@ stt:
     block_ms: 20
     channels: 1
     dtype: "float32"
+  llm_keyword: "루나"
   # Voice activity detection
   # 음성 활동 감지
   vad:


### PR DESCRIPTION
## Summary
- Start STT assist using the Python script rather than a batch file and expose wake-word keyword configuration.
- Show STT assist subtitles in the overlay but forward them to the LLM only when the wake keyword appears.
- Use qwen/qwen3-4b-2507 for tool calls in both normal and assist modes while filtering tools per mode.

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies torch>=2.1.0)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b3d9f93aa48333bf56d163d0979377