### PR TITLE
Wire CMD detector to agent assists with overlay feedback

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -42,3 +42,5 @@
 - Resolved OCR Assist import path so 'tools.tts_espeak' loads regardless of launch directory, gave unique tool IDs for STT/OCR assist to avoid conflicts, and set STT Assist block size to 1s for more real-time listening.
 - STT assist transcripts now flag `assist` and display as "Assist-STT" on the overlay while OCR assist outputs show "Assist-OCR". Voice commands trigger screen capture, LLM-based summarize/translate, focus mode toggling, and repeat of the last action.
 - Root config now exposes STT/OCR assist processes under a shared `tools` block so the agent can launch them without "disabled" warnings. Created `docs/ASSIST_COMMANDS.md` to document assist labels and voice-command triggers; wake-word handling and deeper pipeline integration remain.
+- STT assist and its config now default to the Whisper Tiny Korean model, focusing transcription on Korean; wake-word handling and broader command orchestration still remain.
+- AssistCommandPlugin now triggers overlay toast notifications and publishes OCR/LLM events when voice commands are detected, wiring CMD detection to agent actions.

--- a/STT/Assist-config.yaml
+++ b/STT/Assist-config.yaml
@@ -11,9 +11,9 @@ assist:
     cooldown_ms: 800
 stt:
   engine: faster-whisper
-  model: small           # multilingual
+  model: tiny            # Korean-focused Tiny model
   compute_type: int8     # CPU friendly
-  language: auto         # auto-detect ko/en/ja/zh
+  language: ko           # force Korean recognition
   vad: silero            # or webrtcvad
   sample_rate: 16000     # Hz
   block_ms: 1000         # shorter chunks for real-time responsiveness

--- a/STT/assist.py
+++ b/STT/assist.py
@@ -130,9 +130,9 @@ class AssistConfig:
     """Configuration for assistive STT."""
 
     engine: str = "faster-whisper"
-    model: str = "small"
+    model: str = "tiny"
     compute_type: str = "int8"
-    language: str = "auto"
+    language: str = "ko"
     vad: str = "silero"
     chunk_sec: float = 7.0
     chunk_overlap_sec: float = 0.5

--- a/agent/plugins/assist_cmd_plugin.py
+++ b/agent/plugins/assist_cmd_plugin.py
@@ -28,6 +28,12 @@ class AssistCommandPlugin(BasePlugin):
         self.last_summary: str = ""
         self.prev_cmd: Optional[str] = None
 
+    async def _toast(self, text: str) -> None:
+        """Send a small overlay notification."""
+        await self.ctx.bus.publish(
+            Event(type="overlay.toast", payload={"title": "Assist", "text": text})
+        )
+
     async def handle(self, event):
         if event.type == "ocr.text":
             # Track latest OCR output for summarize/translate commands
@@ -47,11 +53,13 @@ class AssistCommandPlugin(BasePlugin):
             return
 
         if cmd == "capture":
+            await self._toast("📸 캡처")
             await self.ctx.bus.publish(Event(type="ocr.start", payload={}))
 
         elif cmd == "summarize":
             if not self.last_ocr:
                 return
+            await self._toast("📝 요약")
             summary = await self._summarize(self.last_ocr)
             if summary:
                 self.last_summary = summary
@@ -66,6 +74,7 @@ class AssistCommandPlugin(BasePlugin):
             text = self.last_summary if self.prev_cmd == "summarize" and self.last_summary else self.last_ocr
             if not text:
                 return
+            await self._toast("🌐 번역")
             translated = await self._translate(text)
             if translated:
                 await self.ctx.bus.publish(
@@ -76,6 +85,7 @@ class AssistCommandPlugin(BasePlugin):
                 )
 
         elif cmd == "focus":
+            await self._toast("🎯 집중모드")
             await self.ctx.bus.publish(Event(type="FocusMode.toggle", payload={"on": True}))
 
         self.prev_cmd = cmd

--- a/tests/test_assist_cmd_plugin.py
+++ b/tests/test_assist_cmd_plugin.py
@@ -1,0 +1,96 @@
+import asyncio
+from types import SimpleNamespace
+import sys, pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from agent.event_bus import EventBus
+from agent.plugins.assist_cmd_plugin import AssistCommandPlugin
+from agent.schemas import Event
+
+async def dispatch_all(bus: EventBus):
+    while not bus.queue.empty():
+        _, _, e = await bus.queue.get()
+        for prefix, handlers in bus.subscribers.items():
+            if e.type.startswith(prefix):
+                for h in handlers:
+                    await h(e)
+
+
+def test_capture_repeat():
+    async def runner():
+        ctx = SimpleNamespace()
+        ctx.bus = EventBus(dedup_window=0)
+        ctx.config = {}
+        plugin = AssistCommandPlugin(ctx)
+        events = []
+        async def collect(ev):
+            events.append(ev.type)
+        async def noop(ev):
+            pass
+        ctx.bus.subscribe("ocr.", collect)
+        ctx.bus.subscribe("overlay.", noop)
+        await plugin.handle(Event(type="cmd.detected", payload={"cmd": "capture"}))
+        await dispatch_all(ctx.bus)
+        await plugin.handle(Event(type="cmd.detected", payload={"cmd": "repeat"}))
+        await dispatch_all(ctx.bus)
+        assert events == ["ocr.start", "ocr.start"]
+    asyncio.run(runner())
+
+
+def test_summarize_then_translate(monkeypatch):
+    async def runner():
+        ctx = SimpleNamespace()
+        ctx.bus = EventBus(dedup_window=0)
+        ctx.config = {
+            "llm_summary": {"model": "sum"},
+            "translate": {"model": "trans"},
+        }
+        plugin = AssistCommandPlugin(ctx)
+        plugin.last_ocr = "original"
+
+        async def fake_sum(text):
+            assert text == "original"
+            return "summary"
+        inputs = []
+        async def fake_trans(text):
+            inputs.append(text)
+            return "translated"
+        plugin._summarize = fake_sum
+        plugin._translate = fake_trans
+
+        events = []
+        async def collect(ev):
+            events.append(ev.type)
+        async def noop(ev):
+            pass
+        ctx.bus.subscribe("llm.", collect)
+        ctx.bus.subscribe("overlay.", noop)
+
+        await plugin.handle(Event(type="cmd.detected", payload={"cmd": "summarize"}))
+        await dispatch_all(ctx.bus)
+        await plugin.handle(Event(type="cmd.detected", payload={"cmd": "translate"}))
+        await dispatch_all(ctx.bus)
+
+        assert events == ["llm.summary", "llm.translation"]
+        assert inputs == ["summary"]
+    asyncio.run(runner())
+
+
+def test_focus_command():
+    async def runner():
+        ctx = SimpleNamespace()
+        ctx.bus = EventBus(dedup_window=0)
+        ctx.config = {}
+        plugin = AssistCommandPlugin(ctx)
+        states = []
+        async def collect(ev):
+            states.append(ev.payload.get("on"))
+        async def noop(ev):
+            pass
+        ctx.bus.subscribe("FocusMode.", collect)
+        ctx.bus.subscribe("overlay.", noop)
+        await plugin.handle(Event(type="cmd.detected", payload={"cmd": "focus"}))
+        await dispatch_all(ctx.bus)
+        assert states == [True]
+    asyncio.run(runner())


### PR DESCRIPTION
## Summary
- Emit overlay toasts and trigger OCR/LLM/Focus events when voice commands are detected
- Add tests for capture-repeat, summarize-then-translate, and focus commands
- Record the integration in agent memory

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement torch>=2.1.0)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3e985d1c883339161de86e25133ec