### PR TITLE
Enable assist tool calls

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -44,3 +44,7 @@
 - Root config now exposes STT/OCR assist processes under a shared `tools` block so the agent can launch them without "disabled" warnings. Created `docs/ASSIST_COMMANDS.md` to document assist labels and voice-command triggers; wake-word handling and deeper pipeline integration remain.
 - STT assist and its config now default to the Whisper Tiny Korean model, focusing transcription on Korean; wake-word handling and broader command orchestration still remain.
 - AssistCommandPlugin now triggers overlay toast notifications and publishes OCR/LLM events when voice commands are detected, wiring CMD detection to agent actions.
+- Added tool handlers and server support so LLM calls to `stt_assist.start` and `ocr_assist.start` launch the respective assist
+  processes. `cmd_detector.process_text` now posts `cmd.detected` events, enabling voice commands to flow through the agent and
+  overlay for actions like capture, summarize and translate.
+- STT assist now defaults to the Whisper Base model with int8 compute and Korean-only recognition for improved accuracy; wake-word triggers and deeper integration remain.

--- a/Overlay/plugins/tools/config/tools.yaml
+++ b/Overlay/plugins/tools/config/tools.yaml
@@ -47,28 +47,20 @@ tools:
           description: "오디오 파일 경로"
       required: [audio_path]
 
-  - name: ocr_assist
-    module: Overlay.plugins.tools.tool.ocr
-    class: OCR
+  - name: ocr_assist.start
+    module: Overlay.plugins.tools.tool.assist_control
+    class: null
     enabled: true
     desc: "Assist OCR capture"
     input_schema:
       type: object
-      properties:
-        image_path:
-          type: string
-          description: "이미지 파일 경로"
-      required: [image_path]
+      properties: {}
 
-  - name: stt_assist
-    module: Overlay.plugins.tools.tool.stt
-    class: STT
+  - name: stt_assist.start
+    module: Overlay.plugins.tools.tool.assist_control
+    class: null
     enabled: true
     desc: "Assist microphone transcription"
     input_schema:
       type: object
-      properties:
-        audio_path:
-          type: string
-          description: "오디오 파일 경로"
-      required: [audio_path]
+      properties: {}

--- a/Overlay/plugins/tools/tool/assist_control.py
+++ b/Overlay/plugins/tools/tool/assist_control.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+import os
+import requests
+from typing import Dict, Any
+
+_EVENT_URL = os.environ.get("AGENT_EVENT_URL") or os.environ.get("EVENT_URL") or "http://127.0.0.1:8350/event"
+_EVENT_KEY = os.environ.get("AGENT_EVENT_KEY") or os.environ.get("EVENT_KEY")
+
+
+def _post(name: str) -> Dict[str, Any]:
+    headers = {"Content-Type": "application/json"}
+    if _EVENT_KEY:
+        headers["X-Agent-Key"] = _EVENT_KEY
+    try:
+        requests.post(_EVENT_URL, json={"type": name, "payload": {}}, headers=headers, timeout=3)
+    except Exception:
+        pass
+    return {"sent": name}
+
+
+def stt_assist_start(_: Dict[str, Any]) -> Dict[str, Any]:
+    return _post("stt_assist.start")
+
+
+def ocr_assist_start(_: Dict[str, Any]) -> Dict[str, Any]:
+    return _post("ocr_assist.start")
+
+
+def stt_assist_stop(_: Dict[str, Any]) -> Dict[str, Any]:
+    return _post("stt_assist.stop")
+
+
+def ocr_assist_stop(_: Dict[str, Any]) -> Dict[str, Any]:
+    return _post("ocr_assist.stop")
+
+
+TOOL_HANDLERS = {
+    "stt_assist.start": stt_assist_start,
+    "ocr_assist.start": ocr_assist_start,
+    "stt_assist.stop": stt_assist_stop,
+    "ocr_assist.stop": ocr_assist_stop,
+}

--- a/STT/Assist-config.yaml
+++ b/STT/Assist-config.yaml
@@ -11,7 +11,7 @@ assist:
     cooldown_ms: 800
 stt:
   engine: faster-whisper
-  model: tiny            # Korean-focused Tiny model
+  model: base            # Whisper Base model
   compute_type: int8     # CPU friendly
   language: ko           # force Korean recognition
   vad: silero            # or webrtcvad

--- a/STT/README.md
+++ b/STT/README.md
@@ -59,7 +59,7 @@ Recognized utterances are posted as `stt.text` events to the agent bus so the
 accessibility workflow can react. Launch it manually with:
 
 ```bash
-python assist.py --model tiny.en
+python assist.py --model base
 ```
 
 The script auto-selects the system microphone when no device is specified, so

--- a/STT/assist.py
+++ b/STT/assist.py
@@ -8,7 +8,7 @@ If no input device is specified, the first available system microphone is
 chosen automatically for convenience.
 
 Example:
-    python assist.py --model tiny.en
+    python assist.py --model base
 
 The module is designed to be lightweight and testable. The
 `AssistTranscriber` accepts a pre-instantiated model and event posting
@@ -130,7 +130,7 @@ class AssistConfig:
     """Configuration for assistive STT."""
 
     engine: str = "faster-whisper"
-    model: str = "tiny"
+    model: str = "base"
     compute_type: str = "int8"
     language: str = "ko"
     vad: str = "silero"
@@ -377,7 +377,7 @@ def run(cfg: AssistConfig) -> None:
 def main() -> None:
     parser = argparse.ArgumentParser(description="Assistive microphone STT")
     parser.add_argument("--config", help="Path to Assist-config.yaml", default=None)
-    parser.add_argument("--model", help="Whisper model size", default="small")
+    parser.add_argument("--model", help="Whisper model size", default="base")
     parser.add_argument("--device-index", type=int, default=None, help="Input device index")
     parser.add_argument(
         "--block-ms", type=int, default=3000, help="Chunk size in milliseconds"

--- a/STT/cmd_detector.py
+++ b/STT/cmd_detector.py
@@ -1,6 +1,16 @@
 import re
 import time
-from typing import Optional
+import os
+from typing import Optional, Callable
+
+import requests
+
+_EVENT_URL = (
+    os.environ.get("EVENT_URL")
+    or os.environ.get("AGENT_EVENT_URL")
+    or "http://127.0.0.1:8350/event"
+)
+_EVENT_KEY = os.environ.get("EVENT_KEY") or os.environ.get("AGENT_EVENT_KEY")
 
 _LAST_CMD_MS = -1e9
 
@@ -24,6 +34,33 @@ def detect_command(text: str, cfg) -> Optional[str]:
                     _LAST_CMD_MS = now_ms
                     return cmd
     return None
+
+def process_text(text: str, cfg, event_func: Callable[[str, dict, int], None] | None = None) -> Optional[str]:
+    """Detect command and post ``cmd.detected`` event if found.
+
+    Parameters
+    ----------
+    text:
+        Recognized speech text.
+    cfg:
+        Assist configuration containing command mappings.
+    event_func:
+        Optional custom event poster. Defaults to posting to the agent server.
+    """
+    cmd = detect_command(text, cfg)
+    if cmd:
+        _post_event = event_func or _default_post
+        _post_event("cmd.detected", {"cmd": cmd, "ts": time.time()}, 1)
+    return cmd
+
+def _default_post(_type: str, payload: dict, _prio: int = 5) -> None:
+    try:
+        headers = {"Content-Type": "application/json"}
+        if _EVENT_KEY:
+            headers["X-Agent-Key"] = _EVENT_KEY
+        requests.post(_EVENT_URL, json={"type": _type, "payload": payload, "priority": _prio}, headers=headers, timeout=3)
+    except Exception:
+        pass
 
 def _reset_state() -> None:
     global _LAST_CMD_MS

--- a/agent/server.py
+++ b/agent/server.py
@@ -114,14 +114,14 @@ def create_app(ctx, plugins=None):
                     logger.info(f"[plugin] subscribed '{getattr(p,'name',p)}' to '{prefix}'")
 
             async def _stt_handler(ev):
-                if ev.type == "stt.start":
+                if ev.type in ("stt.start", "stt_assist.start"):
                     if app.state.stt_proc and app.state.stt_proc.poll() is None:
                         logger.info("[stt] already running")
                     else:
-                        key = "stt_assist.start" if app.state.assist_mode else "stt.start"
+                        key = "stt_assist.start" if ev.type == "stt_assist.start" or app.state.assist_mode else "stt.start"
                         app.state.stt_proc = _spawn_tool(getattr(ctx, "config", {}), key)
-                elif ev.type == "stt.stop":
-                    if app.state.assist_mode:
+                elif ev.type in ("stt.stop", "stt_assist.stop"):
+                    if app.state.assist_mode and ev.type != "stt_assist.stop":
                         logger.info("[stt] stop ignored in assist mode")
                     else:
                         await _terminate_proc(
@@ -135,13 +135,13 @@ def create_app(ctx, plugins=None):
             app.state._plugin_unsubs.append(("stt.", _stt_handler))
 
             async def _ocr_handler(ev):
-                if ev.type == "ocr.start":
+                if ev.type in ("ocr.start", "ocr_assist.start"):
                     if app.state.ocr_proc and app.state.ocr_proc.poll() is None:
                         logger.info("[ocr] already running")
                     else:
-                        key = "ocr_assist.start" if app.state.assist_mode else "ocr.start"
+                        key = "ocr_assist.start" if ev.type == "ocr_assist.start" or app.state.assist_mode else "ocr.start"
                         app.state.ocr_proc = _spawn_tool(getattr(ctx, "config", {}), key)
-                elif ev.type == "ocr.stop":
+                elif ev.type in ("ocr.stop", "ocr_assist.stop"):
                     await _terminate_proc(getattr(app.state, "ocr_proc", None), name="ocr", timeout=3.0)
                     app.state.ocr_proc = None
 

--- a/tools/config/tools.yaml
+++ b/tools/config/tools.yaml
@@ -47,28 +47,20 @@ tools:
           description: "오디오 파일 경로"
       required: [audio_path]
 
-  - name: ocr_assist
-    module: tools.tool.ocr
-    class: OCR
+  - name: ocr_assist.start
+    module: tools.tool.assist_control
+    class: null
     enabled: true
     desc: "Assist OCR capture"
     input_schema:
       type: object
-      properties:
-        image_path:
-          type: string
-          description: "이미지 파일 경로"
-      required: [image_path]
+      properties: {}
 
-  - name: stt_assist
-    module: tools.tool.stt
-    class: STT
+  - name: stt_assist.start
+    module: tools.tool.assist_control
+    class: null
     enabled: true
     desc: "Assist microphone transcription"
     input_schema:
       type: object
-      properties:
-        audio_path:
-          type: string
-          description: "오디오 파일 경로"
-      required: [audio_path]
+      properties: {}

--- a/tools/tool/assist_control.py
+++ b/tools/tool/assist_control.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+import os
+import requests
+from typing import Dict, Any
+
+_EVENT_URL = os.environ.get("AGENT_EVENT_URL") or os.environ.get("EVENT_URL") or "http://127.0.0.1:8350/event"
+_EVENT_KEY = os.environ.get("AGENT_EVENT_KEY") or os.environ.get("EVENT_KEY")
+
+
+def _post(name: str) -> Dict[str, Any]:
+    headers = {"Content-Type": "application/json"}
+    if _EVENT_KEY:
+        headers["X-Agent-Key"] = _EVENT_KEY
+    try:
+        requests.post(_EVENT_URL, json={"type": name, "payload": {}}, headers=headers, timeout=3)
+    except Exception:
+        pass
+    return {"sent": name}
+
+
+def stt_assist_start(_: Dict[str, Any]) -> Dict[str, Any]:
+    return _post("stt_assist.start")
+
+
+def ocr_assist_start(_: Dict[str, Any]) -> Dict[str, Any]:
+    return _post("ocr_assist.start")
+
+
+def stt_assist_stop(_: Dict[str, Any]) -> Dict[str, Any]:
+    return _post("stt_assist.stop")
+
+
+def ocr_assist_stop(_: Dict[str, Any]) -> Dict[str, Any]:
+    return _post("ocr_assist.stop")
+
+
+TOOL_HANDLERS = {
+    "stt_assist.start": stt_assist_start,
+    "ocr_assist.start": ocr_assist_start,
+    "stt_assist.stop": stt_assist_stop,
+    "ocr_assist.stop": ocr_assist_stop,
+}


### PR DESCRIPTION
## Summary
- allow `stt_assist.start` and `ocr_assist.start` tool calls to launch assist processes
- forward detected voice commands via new `process_text` helper
- expose assist start tools to overlay and runtime registries
- default STT assist to Whisper Base int8 with Korean-only recognition

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement torch>=2.1.0)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3f13211888333bd73c3156c34cff9