### PR TITLE
feat: spawn assist tools via llm events

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -48,3 +48,5 @@
   processes. `cmd_detector.process_text` now posts `cmd.detected` events, enabling voice commands to flow through the agent and
   overlay for actions like capture, summarize and translate.
 - STT assist now defaults to the Whisper Base model with int8 compute and Korean-only recognition for improved accuracy; wake-word triggers and deeper integration remain.
+- AssistCommandPlugin now posts a '📋 Cmd Detected' overlay toast and dispatches capture/summarize/translate prompts to local LLMs. Wake-word triggers and further assist features remain.
+- Agent server now listens for 'stt_assist.*' and 'ocr_assist.*' events so LLM tool calls launch the assist STT/OCR scripts; capture commands dispatch 'ocr_assist.start'.

--- a/agent/plugins/assist_cmd_plugin.py
+++ b/agent/plugins/assist_cmd_plugin.py
@@ -44,6 +44,9 @@ class AssistCommandPlugin(BasePlugin):
         cmd = event.payload.get("cmd")
         if not cmd:
             return
+        await self.ctx.bus.publish(
+            Event(type="overlay.toast", payload={"title": "📋 Cmd Detected", "text": cmd})
+        )
         await self._execute(cmd)
 
     async def _execute(self, cmd: str) -> None:
@@ -54,7 +57,7 @@ class AssistCommandPlugin(BasePlugin):
 
         if cmd == "capture":
             await self._toast("📸 캡처")
-            await self.ctx.bus.publish(Event(type="ocr.start", payload={}))
+            await self.ctx.bus.publish(Event(type="ocr_assist.start", payload={}))
 
         elif cmd == "summarize":
             if not self.last_ocr:

--- a/agent/server.py
+++ b/agent/server.py
@@ -132,7 +132,9 @@ def create_app(ctx, plugins=None):
                         app.state.stt_proc = None
 
             ctx.bus.subscribe("stt.", _stt_handler)
+            ctx.bus.subscribe("stt_assist.", _stt_handler)
             app.state._plugin_unsubs.append(("stt.", _stt_handler))
+            app.state._plugin_unsubs.append(("stt_assist.", _stt_handler))
 
             async def _ocr_handler(ev):
                 if ev.type in ("ocr.start", "ocr_assist.start"):
@@ -146,7 +148,9 @@ def create_app(ctx, plugins=None):
                     app.state.ocr_proc = None
 
             ctx.bus.subscribe("ocr.", _ocr_handler)
+            ctx.bus.subscribe("ocr_assist.", _ocr_handler)
             app.state._plugin_unsubs.append(("ocr.", _ocr_handler))
+            app.state._plugin_unsubs.append(("ocr_assist.", _ocr_handler))
 
             async def _assist_handler(ev):
                 if ev.type == "assist.on":

--- a/tests/test_assist_cmd_plugin.py
+++ b/tests/test_assist_cmd_plugin.py
@@ -17,6 +17,25 @@ async def dispatch_all(bus: EventBus):
                     await h(e)
 
 
+def test_cmd_detected_toast():
+    async def runner():
+        ctx = SimpleNamespace()
+        ctx.bus = EventBus(dedup_window=0)
+        ctx.config = {}
+        plugin = AssistCommandPlugin(ctx)
+        toasts = []
+
+        async def collect(ev):
+            toasts.append((ev.payload.get("title"), ev.payload.get("text")))
+
+        ctx.bus.subscribe("overlay.", collect)
+        await plugin.handle(Event(type="cmd.detected", payload={"cmd": "capture"}))
+        await dispatch_all(ctx.bus)
+        assert toasts[0] == ("📋 Cmd Detected", "capture")
+
+    asyncio.run(runner())
+
+
 def test_capture_repeat():
     async def runner():
         ctx = SimpleNamespace()
@@ -28,13 +47,13 @@ def test_capture_repeat():
             events.append(ev.type)
         async def noop(ev):
             pass
-        ctx.bus.subscribe("ocr.", collect)
+        ctx.bus.subscribe("ocr_assist.", collect)
         ctx.bus.subscribe("overlay.", noop)
         await plugin.handle(Event(type="cmd.detected", payload={"cmd": "capture"}))
         await dispatch_all(ctx.bus)
         await plugin.handle(Event(type="cmd.detected", payload={"cmd": "repeat"}))
         await dispatch_all(ctx.bus)
-        assert events == ["ocr.start", "ocr.start"]
+        assert events == ["ocr_assist.start", "ocr_assist.start"]
     asyncio.run(runner())
 
 

--- a/tests/test_server_assist_tools.py
+++ b/tests/test_server_assist_tools.py
@@ -1,0 +1,53 @@
+import asyncio
+from types import SimpleNamespace
+
+import agent.server as server
+from agent.event_bus import EventBus
+from agent.schemas import Event
+
+
+class DummyProc:
+    def poll(self):
+        return None
+
+    def terminate(self):
+        pass
+
+
+def test_assist_tool_events(monkeypatch):
+    async def runner():
+        ctx = SimpleNamespace()
+        ctx.bus = EventBus()
+        ctx.config = {}
+        ctx.assist_mode = False
+
+        spawns = []
+
+        def dummy_spawn(cfg, key):
+            spawns.append(key)
+            return DummyProc()
+
+        monkeypatch.setattr(server, "_spawn_tool", dummy_spawn)
+
+        app = server.create_app(ctx)
+        async with app.router.lifespan_context(app):
+            stt_handler = None
+            ocr_handler = None
+            for prefix, h in app.state._plugin_unsubs:
+                if prefix == "stt_assist.":
+                    stt_handler = h
+                elif prefix == "ocr_assist.":
+                    ocr_handler = h
+            assert stt_handler is not None
+            assert ocr_handler is not None
+
+            await stt_handler(Event(type="stt_assist.start", payload={}))
+            await ocr_handler(Event(type="ocr_assist.start", payload={}))
+
+        assert spawns == ["stt_assist.start", "ocr_assist.start"]
+
+    try:
+        asyncio.run(runner())
+    except asyncio.CancelledError:
+        pass
+


### PR DESCRIPTION
## Summary
- allow agent server to handle `stt_assist.*` and `ocr_assist.*` events so LLM tool calls launch assist scripts
- route capture commands to `ocr_assist.start`
- cover assist tool spawning with new tests

## Testing
- `pip install -r requirements.txt` (fails: Could not find a version that satisfies the requirement torch>=2.1.0)
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b3f6aa54248333b3c067735d2150ad