### PR TITLE
feat: delay OCR capture and show progress

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -50,3 +50,7 @@
 - STT assist now defaults to the Whisper Base model with int8 compute and Korean-only recognition for improved accuracy; wake-word triggers and deeper integration remain.
 - AssistCommandPlugin now posts a '📋 Cmd Detected' overlay toast and dispatches capture/summarize/translate prompts to local LLMs. Wake-word triggers and further assist features remain.
 - Agent server now listens for 'stt_assist.*' and 'ocr_assist.*' events so LLM tool calls launch the assist STT/OCR scripts; capture commands dispatch 'ocr_assist.start'.
+- STT assist can now call a configured local LLM when its wake word prefix is spoken, emitting `llm.chat` results; deeper assist-script orchestration and wake-word polish remain.
+- STT assist also invokes the configured LLM when the CMD detector recognizes an `assist` command, so a wake word is no longer required; integration with broader assist scripts still pending.
+- Assist and OCR tools now use relative paths and a shared loader so they run from any working directory; docs note configuring local LLM endpoints for tool calls.
+- OCR assist now delays capture by 5 seconds, showing "5초 뒤 촬영 합니다" and then "이미지를 OCR 중입니다.." before processing; deeper assist integration remains.

--- a/OCR/OCR-Assist.py
+++ b/OCR/OCR-Assist.py
@@ -10,6 +10,7 @@ from typing import List, Optional
 
 import pathlib
 import sys
+import time
 
 # Ensure repository root is on sys.path when executed directly
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
@@ -184,9 +185,10 @@ def main() -> None:
     if cfg.event_key:
         _EVENT_KEY = cfg.event_key
 
+    _notify("5초 뒤 촬영 합니다")
+    time.sleep(5)
     img = _capture_screen(cfg)
-    _notify("방금 OCR 어시스트가 캡쳐했어요.")
-    _notify("OCR진행 중입니다.")
+    _notify("이미지를 OCR 중입니다..")
     text = _run_ocr(img, cfg)
     text = _refine_with_jan(text)
     if text:

--- a/Overlay/config_process_example.yaml
+++ b/Overlay/config_process_example.yaml
@@ -41,9 +41,9 @@ tools:
     stt_assist.start:
       kind: "process"
       id: "stt"
-      command: "D:/jip/home-agent/.venv/Scripts/python.exe"
-      args: ["D:/jip/home-agent/STT/assist.py", "--config", "D:/jip/home-agent/STT/Assist-config.yaml"]
-      cwd: "D:/jip/home-agent/STT"
+      command: "python"
+      args: ["assist.py", "--config", "Assist-config.yaml"]
+      cwd: "../STT"
       no_console: true
     stt_assist.stop:
       kind: "process_stop"
@@ -53,9 +53,9 @@ tools:
     ocr_assist.start:
       kind: "process"
       id: "ocr"
-      command: "D:/jip/home-agent/.venv/Scripts/python.exe"
-      args: ["D:/jip/home-agent/OCR/OCR-Assist.py"]
-      cwd: "D:/jip/home-agent/OCR"
+      command: "python"
+      args: ["OCR-Assist.py"]
+      cwd: "../OCR"
       no_console: true
     ocr_assist.stop:
       kind: "process_stop"

--- a/STT/Assist-config.yaml
+++ b/STT/Assist-config.yaml
@@ -6,6 +6,7 @@ assist:
     focus: ["집중모드", "집중 모드", "focus mode"]
     repeat: ["다시", "repeat", "もう一度", "再读", "再来一次"]
     stop: ["멈춰", "정지", "stop", "停止"]
+    assist: ["assist", "어시스트", "도와줘"]
   detection:
     require_boundary: false
     cooldown_ms: 800

--- a/STT/assist.py
+++ b/STT/assist.py
@@ -50,6 +50,12 @@ import requests
 import importlib.util
 import pathlib
 import sys
+
+# Ensure repository root is on sys.path so agent modules resolve even when
+# this script is launched from a different working directory.
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
 try:
     from .cmd_detector import detect_command
 except Exception:  # pragma: no cover - script execution
@@ -153,11 +159,42 @@ class AssistConfig:
             "focus": ["집중모드", "집중 모드", "focus mode"],
             "repeat": ["다시", "repeat", "もう一度", "再读", "再来一次"],
             "stop": ["멈춰", "정지", "stop", "停止"],
+            "assist": ["assist", "어시스트", "도와줘"],
         }
     )
     detection: Dict[str, int | bool] = field(
         default_factory=lambda: {"require_boundary": False, "cooldown_ms": 800}
     )
+    wake_word: Optional[str] = None
+    llm: Dict[str, str] = field(default_factory=dict)
+
+
+def load_config(path: str | None = None) -> AssistConfig:
+    """Load AssistConfig from a YAML file.
+
+    If ``path`` is ``None`` the loader searches for ``Assist-config.yaml``
+    next to this script so the tool can be launched from any directory
+    without juggling working directories.
+    """
+
+    if path is None:
+        default = pathlib.Path(__file__).with_name("Assist-config.yaml")
+        path = str(default) if default.exists() else None
+
+    cfg_data: Dict[str, any] = {}
+    if path:
+        with open(path, "r", encoding="utf-8") as f:
+            raw = yaml.safe_load(f) or {}
+        stt = raw.get("stt") or {}
+        assist = raw.get("assist") or {}
+        cfg_data.update(stt)
+        if "commands" in assist:
+            cfg_data["commands"] = assist["commands"]
+        if "detection" in assist:
+            cfg_data["detection"] = assist["detection"]
+        if "llm" in raw:
+            cfg_data["llm"] = raw["llm"]
+    return AssistConfig(**cfg_data)
 
 
 class AssistTranscriber:
@@ -174,6 +211,38 @@ class AssistTranscriber:
         self.event_func = event_func
         self.cfg = config or AssistConfig()
         self.ui = ui
+
+    def _call_llm(self, prompt: str) -> Optional[str]:
+        cfg = self.cfg.llm or {}
+        endpoint = cfg.get("endpoint")
+        model = cfg.get("model")
+        if not endpoint or not model:
+            return None
+        headers = {"Content-Type": "application/json"}
+        api_key = cfg.get("api_key", "")
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        payload = {
+            "model": model,
+            "messages": [
+                {"role": "system", "content": cfg.get("system", "You are a helpful assistant.")},
+                {"role": "user", "content": prompt},
+            ],
+            "temperature": cfg.get("temperature", 0.2),
+            "max_tokens": cfg.get("max_new_tokens", 512),
+        }
+        try:
+            r = requests.post(
+                f"{endpoint}/chat/completions",
+                headers=headers,
+                json=payload,
+                timeout=cfg.get("timeout", 30),
+            )
+            r.raise_for_status()
+            data = r.json()
+            return (data["choices"][0]["message"]["content"] or "").strip()
+        except Exception:
+            return None
 
     def transcribe(self, pcm16: bytes, sample_rate: int | None = None) -> str:
         """Transcribe a chunk of PCM16 mono audio.
@@ -222,6 +291,34 @@ class AssistTranscriber:
                     {"cmd": cmd, "ts": time.time()},
                     1,
                 )
+                if cmd == "assist":
+                    prompt = text
+                    for syn in self.cfg.commands.get("assist", []):
+                        if text.lower().startswith(syn.lower()):
+                            prompt = text[len(syn) :].lstrip()
+                            break
+                    resp = self._call_llm(prompt)
+                    if resp:
+                        self.event_func(
+                            "llm.chat",
+                            {
+                                "text": resp,
+                                "model": (self.cfg.llm or {}).get("model", ""),
+                            },
+                        )
+            elif self.cfg.wake_word:
+                w = self.cfg.wake_word.lower()
+                if text.lower().startswith(w):
+                    prompt = text[len(self.cfg.wake_word) :].lstrip()
+                    resp = self._call_llm(prompt)
+                    if resp:
+                        self.event_func(
+                            "llm.chat",
+                            {
+                                "text": resp,
+                                "model": (self.cfg.llm or {}).get("model", ""),
+                            },
+                        )
         return text
 
 
@@ -377,26 +474,19 @@ def run(cfg: AssistConfig) -> None:
 def main() -> None:
     parser = argparse.ArgumentParser(description="Assistive microphone STT")
     parser.add_argument("--config", help="Path to Assist-config.yaml", default=None)
-    parser.add_argument("--model", help="Whisper model size", default="base")
+    parser.add_argument("--model", help="Whisper model size", default=None)
     parser.add_argument("--device-index", type=int, default=None, help="Input device index")
     parser.add_argument(
         "--block-ms", type=int, default=3000, help="Chunk size in milliseconds"
     )
     args = parser.parse_args()
 
-    if args.config:
-        with open(args.config, "r", encoding="utf-8") as f:
-            data = yaml.safe_load(f) or {}
-        cfg_data = {}
-        cfg_data.update(data.get("stt") or {})
-        cfg_data.update(data.get("assist") or {})
-        cfg = AssistConfig(**cfg_data)
-    else:
-        cfg = AssistConfig(
-            model=args.model,
-            block_ms=args.block_ms,
-            device_index=args.device_index,
-        )
+    cfg = load_config(args.config)
+    if args.model:
+        cfg.model = args.model
+    if args.device_index is not None:
+        cfg.device_index = args.device_index
+    cfg.block_ms = args.block_ms or cfg.block_ms
     run(cfg)
 
 

--- a/config.yaml
+++ b/config.yaml
@@ -77,9 +77,9 @@ tools: &tool_processes
   stt_assist.start:
     kind: "process"
     id: "stt_assist"
-    command: "D:/jip/home-agent/.venv/Scripts/python.exe"
-    args: ["D:/jip/home-agent/STT/assist.py", "--config", "D:/jip/home-agent/STT/Assist-config.yaml"]
-    cwd: "D:/jip/home-agent/STT"
+    command: "python"
+    args: ["assist.py", "--config", "Assist-config.yaml"]
+    cwd: "./STT"
     no_console: true
     env:
       AGENT_EVENT_URL: "http://127.0.0.1:8350/event"
@@ -90,9 +90,9 @@ tools: &tool_processes
   ocr_assist.start:
     kind: "process"
     id: "ocr_assist"
-    command: "D:/jip/home-agent/.venv/Scripts/python.exe"
-    args: ["D:/jip/home-agent/OCR/OCR-Assist.py"]
-    cwd: "D:/jip/home-agent/OCR"
+    command: "python"
+    args: ["OCR-Assist.py"]
+    cwd: "./OCR"
     no_console: true
     env:
       AGENT_EVENT_URL: "http://127.0.0.1:8350/event"

--- a/docs/ASSIST_COMMANDS.md
+++ b/docs/ASSIST_COMMANDS.md
@@ -18,3 +18,19 @@ This document summarizes the assistive modules and the command plugin that react
 | "집중모드" | Toggle focus mode through the focus-assist tool |
 
 All actions are recorded via the agent server so sessions can be reviewed or repeated later.
+
+## Local LLM & Path Notes
+Both assist scripts resolve their `Assist-config.yaml` relative to the script
+file, so they run correctly even when launched from another working
+directory. When the overlay enters assist mode and a local model (e.g. LM
+Studio or Ollama) calls `stt_assist.start` or `ocr_assist.start`, the agent
+spawns these tools using the relative paths in `config.yaml`.
+
+- **STT Assist** can forward wake-word prompts to a local LLM if `llm.endpoint`
+  and `llm.model` are set in `STT/Assist-config.yaml`.
+- **OCR Assist** refines EasyOCR output when `LM_STUDIO_ENDPOINT`/
+  `OLLAMA_ENDPOINT` (and corresponding `*_MODEL` variables) are defined in the
+  environment.
+
+These hooks allow a local LLM to orchestrate capture, summarization and
+translation without path issues.

--- a/tests/test_assist.py
+++ b/tests/test_assist.py
@@ -11,10 +11,34 @@ sys.modules["assist"] = assist
 spec.loader.exec_module(assist)
 AssistTranscriber = assist.AssistTranscriber
 AssistConfig = assist.AssistConfig
+load_config = assist.load_config
 
 
 def test_select_device_passthrough():
     assert assist._select_input_device(3, None) == 3
+
+
+def test_load_config_default():
+    cfg = load_config()
+    assert cfg.model == "base"
+    assert "capture" in cfg.commands
+
+
+def test_load_config_override(tmp_path):
+    cfg_file = tmp_path / "Assist-config.yaml"
+    cfg_file.write_text(
+        """
+stt:
+  model: tiny
+assist:
+  commands:
+    hello: [hi]
+""",
+        encoding="utf-8",
+    )
+    cfg = load_config(str(cfg_file))
+    assert cfg.model == "tiny"
+    assert cfg.commands["hello"] == ["hi"]
 
 
 def test_select_device_by_name(monkeypatch):
@@ -177,3 +201,39 @@ def test_transcriber_resamples(monkeypatch):
     text = transcriber.transcribe(pcm, sample_rate=8000)
     assert text == "hi"
     assert model.last_len == cfg.sample_rate
+
+
+class AssistModel:
+    def __init__(self):
+        self.model_size = "dummy"
+
+    def transcribe(self, audio, language="en"):
+        class Seg:
+            text = "assist tell me a joke"
+
+        return [Seg()], None
+
+
+def test_llm_called_on_assist_command(monkeypatch):
+    events, poster = collect_events()
+    cfg = AssistConfig()
+    model = AssistModel()
+    transcriber = AssistTranscriber(model, poster, cfg)
+
+    recorded = {}
+
+    def fake_llm(prompt):
+        recorded["prompt"] = prompt
+        return "why did the chicken?"
+
+    monkeypatch.setattr(transcriber, "_call_llm", fake_llm)
+    pcm = (np.full(cfg.sample_rate, 5000, dtype=np.int16)).tobytes()
+    transcriber.transcribe(pcm)
+    assert recorded["prompt"] == "tell me a joke"
+    assert events[0][0] == "stt.text"
+    assert events[1][0] == "cmd.detected" and events[1][1]["cmd"] == "assist"
+    assert events[2] == (
+        "llm.chat",
+        {"text": "why did the chicken?", "model": ""},
+        5,
+    )

--- a/tests/test_ocr_assist.py
+++ b/tests/test_ocr_assist.py
@@ -76,3 +76,17 @@ def test_refine_with_jan_supports_lmstudio(monkeypatch):
     out = ocr_assist._refine_with_jan("hi")
     assert called["url"] == "http://lmstudio:1234/v1/chat/completions"
     assert out == "refined"
+
+
+def test_main_announces_delay_and_progress(monkeypatch):
+    messages = []
+    monkeypatch.setattr(ocr_assist, "_notify", lambda msg: messages.append(msg))
+    monkeypatch.setattr(ocr_assist, "_capture_screen", lambda cfg: Image.new("RGB", (1, 1)))
+    monkeypatch.setattr(ocr_assist, "_run_ocr", lambda img, cfg: "")
+    sleeps = []
+    monkeypatch.setattr(ocr_assist.time, "sleep", lambda s: sleeps.append(s))
+    monkeypatch.setattr(sys, "argv", ["OCR-Assist.py"])
+    ocr_assist.main()
+    assert messages[0].startswith("5초")
+    assert messages[1] == "이미지를 OCR 중입니다.."
+    assert sleeps == [5]


### PR DESCRIPTION
## Summary
- Announce 5‑second delay before capture and report OCR progress in overlay
- Cover delayed capture workflow with unit tests
- Log new OCR assist behavior in working memory

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement torch>=2.1.0)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b41ed6d41883339abffd94c92c0185