### PR TITLE
feat: route voice commands through server

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -56,3 +56,4 @@
 - OCR assist now delays capture by 5 seconds, showing "5초 뒤 촬영 합니다" and then "이미지를 OCR 중입니다.." before processing; deeper assist integration remains.
 - AssistCommandPlugin now performs combined summarize+translate when needed, caching summaries so repeated 번역 commands reuse the summary. Further context-caching and repeat behavior refinements remain.
 - AssistCommandPlugin now minimizes LLM context with fixed prompts and SHA1-based caching for summarize/translate tasks, storing last translation. Further STT window tracking and broader context store remain.
+- Command router added to server so cmd.capture/assist/stop events trigger OCR/assist processes and cleanup, and EventBus now supports unsubscribe for clean shutdown. Assist and OCR configs force event.url to 8765 to avoid mismatched ports. Mapping for other commands like summarize/translate still pending.

--- a/OCR/Assist-config.yaml
+++ b/OCR/Assist-config.yaml
@@ -6,7 +6,7 @@ capture:
   region: null      # optional [left, top, width, height]
 
 event:
-  url: http://127.0.0.1:8350/event
+  url: http://127.0.0.1:8765/event
   key: null
 
 ocr:

--- a/STT/Assist-config.yaml
+++ b/STT/Assist-config.yaml
@@ -10,6 +10,9 @@ assist:
   detection:
     require_boundary: false
     cooldown_ms: 800
+event:
+  url: http://127.0.0.1:8765/event
+  key: null
 stt:
   engine: faster-whisper
   model: base            # Whisper Base model

--- a/agent/event_bus.py
+++ b/agent/event_bus.py
@@ -44,6 +44,17 @@ class EventBus:
     def subscribe(self, event_prefix: str, handler: Callable[[Event], None]):
         self.subscribers.setdefault(event_prefix, []).append(handler)
 
+    def unsubscribe(self, event_prefix: str, handler: Callable[[Event], None]):
+        handlers = self.subscribers.get(event_prefix)
+        if not handlers:
+            return
+        try:
+            handlers.remove(handler)
+        except ValueError:
+            pass
+        if not handlers:
+            self.subscribers.pop(event_prefix, None)
+
     async def run(self):
         logger.info("EventBus loop started.")
         while True:

--- a/agent/server.py
+++ b/agent/server.py
@@ -192,6 +192,60 @@ def create_app(ctx, plugins=None):
             ctx.bus.subscribe("assist.", _assist_handler)
             app.state._plugin_unsubs.append(("assist.", _assist_handler))
 
+            async def _cmd_handler(ev):
+                # 1) typed 이벤트 지원 (cmd.capture 등)
+                if ev.type.startswith("cmd."):
+                    c = ev.type.split(".", 1)[1]
+                # 2) generic 이벤트(cmd.detected) 지원
+                else:
+                    c = (ev.payload or {}).get("cmd")
+
+                if not c:
+                    return
+
+                # 중복 억제용 타임스탬프
+                import time as _t
+                ts = ev.payload.get("ts") if isinstance(ev.payload, dict) else None
+                if not ts:
+                    ts = _t.time()
+
+                # 라우팅
+                if c == "capture":
+                    # assist 모드면 ocr_assist.start, 아니면 ocr.start
+                    etype = "ocr_assist.start" if app.state.assist_mode else "ocr.start"
+                    await ctx.bus.publish(Event(
+                        type=etype,
+                        payload={"reason": "voice_cmd", "cmd": c, "ts": ts},
+                        priority=2,
+                        source="router",
+                        timestamp=_t.time(),
+                    ))
+                elif c == "assist":
+                    await ctx.bus.publish(Event(
+                        type="assist.on",
+                        payload={"ts": ts},
+                        priority=5,
+                        source="router",
+                        timestamp=_t.time(),
+                    ))
+                elif c == "stop":
+                    # 보조모드 종료 + OCR/STM 정리
+                    await ctx.bus.publish(Event(
+                        type="assist.off",
+                        payload={"ts": ts},
+                        priority=5,
+                        source="router",
+                        timestamp=_t.time(),
+                    ))
+                    await ctx.bus.publish(Event(type="ocr.stop", payload={}, priority=3, source="router", timestamp=_t.time()))
+                    await ctx.bus.publish(Event(type="stt.stop", payload={}, priority=3, source="router", timestamp=_t.time()))
+                # 필요하면 여기서 summarize/translate 등도 매핑
+
+            ctx.bus.subscribe("cmd.", _cmd_handler)
+            ctx.bus.subscribe("cmd.detected", _cmd_handler)  # generic도 받기
+            app.state._plugin_unsubs.append(("cmd.", _cmd_handler))
+            app.state._plugin_unsubs.append(("cmd.detected", _cmd_handler))
+
             # Start event bus loop
             app.state.bus_task = asyncio.create_task(ctx.bus.run())
             yield


### PR DESCRIPTION
## Summary
- route `cmd.capture`, `cmd.assist`, and `cmd.stop` events to OCR, assist mode, and cleanup
- add `unsubscribe` to `EventBus` for tidy shutdown
- point STT and OCR assist configs at the agent server's event URL

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement torch>=2.1.0)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4dbcd1db88333ab9d3f4e5a575d99