### PR TITLE
Handle cmd.detected events to launch OCR

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -57,3 +57,4 @@
 - AssistCommandPlugin now performs combined summarize+translate when needed, caching summaries so repeated 번역 commands reuse the summary. Further context-caching and repeat behavior refinements remain.
 - AssistCommandPlugin now minimizes LLM context with fixed prompts and SHA1-based caching for summarize/translate tasks, storing last translation. Further STT window tracking and broader context store remain.
 - Command router added to server so cmd.capture/assist/stop events trigger OCR/assist processes and cleanup, and EventBus now supports unsubscribe for clean shutdown. Assist and OCR configs force event.url to 8765 to avoid mismatched ports. Mapping for other commands like summarize/translate still pending.
+- Command router now parses cmd.detected payloads so capture voice commands launch the appropriate OCR process; added tests for cmd->ocr routing.

--- a/agent/server.py
+++ b/agent/server.py
@@ -193,12 +193,14 @@ def create_app(ctx, plugins=None):
             app.state._plugin_unsubs.append(("assist.", _assist_handler))
 
             async def _cmd_handler(ev):
-                # 1) typed 이벤트 지원 (cmd.capture 등)
-                if ev.type.startswith("cmd."):
-                    c = ev.type.split(".", 1)[1]
-                # 2) generic 이벤트(cmd.detected) 지원
-                else:
+                # ``cmd.detected``는 payload 에서 명령을 추출해야 하므로 먼저 검사
+                if ev.type == "cmd.detected":
                     c = (ev.payload or {}).get("cmd")
+                # 그 외 ``cmd.*`` 타입은 이벤트명으로부터 명령을 파싱
+                elif ev.type.startswith("cmd."):
+                    c = ev.type.split(".", 1)[1]
+                else:
+                    c = None
 
                 if not c:
                     return
@@ -243,6 +245,7 @@ def create_app(ctx, plugins=None):
 
             ctx.bus.subscribe("cmd.", _cmd_handler)
             ctx.bus.subscribe("cmd.detected", _cmd_handler)  # generic도 받기
+            logger.info("[router] subscribed to 'cmd.*' and 'cmd.detected'")
             app.state._plugin_unsubs.append(("cmd.", _cmd_handler))
             app.state._plugin_unsubs.append(("cmd.detected", _cmd_handler))
 

--- a/tests/test_cmd_router.py
+++ b/tests/test_cmd_router.py
@@ -1,0 +1,46 @@
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+import asyncio
+from types import SimpleNamespace
+
+from agent.event_bus import EventBus
+from agent.server import create_app
+from agent.schemas import Event
+
+
+async def dispatch_all(bus: EventBus):
+    while not bus.queue.empty():
+        _, _, e = await bus.queue.get()
+        for prefix, handlers in bus.subscribers.items():
+            if e.type.startswith(prefix):
+                for h in handlers:
+                    await h(e)
+
+
+async def _run(ctx, subscribe_prefix):
+    app = create_app(ctx, plugins=[])
+    events = []
+    try:
+        async with app.router.lifespan_context(app):
+            async def collect(ev):
+                events.append(ev.type)
+            ctx.bus.subscribe(subscribe_prefix, collect)
+            handler = ctx.bus.subscribers["cmd.detected"][0]
+            await handler(Event(type="cmd.detected", payload={"cmd": "capture"}))
+            await dispatch_all(ctx.bus)
+    except asyncio.CancelledError:
+        pass
+    return events
+
+
+def test_cmd_detected_to_ocr():
+    ctx = SimpleNamespace(config={}, bus=EventBus(dedup_window=0), assist_mode=False)
+    events = asyncio.run(_run(ctx, "ocr."))
+    assert events == ["ocr.start"]
+
+
+def test_cmd_detected_to_ocr_assist():
+    ctx = SimpleNamespace(config={}, bus=EventBus(dedup_window=0), assist_mode=True)
+    events = asyncio.run(_run(ctx, "ocr_assist."))
+    assert events == ["ocr_assist.start"]
+


### PR DESCRIPTION
## Summary
- parse `cmd.detected` payloads before handling other `cmd.*` events so capture commands start the correct OCR process
- test cmd routing for normal and assist modes

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement torch>=2.1.0)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4e25662108333a1fd6fd14d40cdf4