### PR TITLE
feat: add structured tool call gateway

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -58,3 +58,7 @@
 - AssistCommandPlugin now minimizes LLM context with fixed prompts and SHA1-based caching for summarize/translate tasks, storing last translation. Further STT window tracking and broader context store remain.
 - Command router added to server so cmd.capture/assist/stop events trigger OCR/assist processes and cleanup, and EventBus now supports unsubscribe for clean shutdown. Assist and OCR configs force event.url to 8765 to avoid mismatched ports. Mapping for other commands like summarize/translate still pending.
 - Command router now parses cmd.detected payloads so capture voice commands launch the appropriate OCR process; added tests for cmd->ocr routing.
+- Added tool_gateway module to validate tool calls, map them to events with correlation/idempotency metadata, and tests covering assist-mode routing. Full integration with LLM runner pending.
+- Defined tool call contract via schemas/tool_calls.json and added Qwen system prompt requiring tool-only responses; tool gateway now loads schemas from file for validation.
+- Added stt_start/stt_stop and ocr_start/ocr_stop to the tool call schema and gateway so normal STT/OCR tools are invoked via structured tool_calls; further LLM integration remains.
+- Added assist_on tool and rerouted stt/ocr_start to assist events when assist mode is active; ocr_capture now always starts OCR assist and prompt examples teach models to avoid assist tools unless explicitly requested.

--- a/agent/tool_gateway.py
+++ b/agent/tool_gateway.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+import json
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List
+
+from loguru import logger
+
+try:
+    import jsonschema
+except Exception:  # pragma: no cover - best effort if jsonschema missing
+    jsonschema = None
+
+from .schemas import Event
+
+# Load tool definitions and derive JSON Schemas
+TOOLS_PATH = Path(__file__).resolve().parent.parent / "schemas" / "tool_calls.json"
+with TOOLS_PATH.open("r", encoding="utf-8") as f:
+    TOOLS: List[Dict[str, Any]] = json.load(f)
+SCHEMAS: Dict[str, Dict[str, Any]] = {
+    t["function"]["name"]: t["function"]["parameters"] for t in TOOLS
+}
+
+# Tool name to event mapping
+TOOL_ROUTES = {
+    "stt_assist_start": lambda args, ctx: [
+        ("assist.on", {"reason": "tool", "args": args}),
+        ("stt_assist.start", {"reason": "tool"}),
+    ],
+    "ocr_capture": lambda args, ctx: [
+        ("ocr_assist.start", {"region": args.get("region")})
+    ],
+    "assist_on": lambda args, ctx: [("assist.on", {"reason": "tool"})],
+    "assist_off": lambda args, ctx: [
+        ("assist.off", {"reason": "tool"}),
+        ("stt.stop", {"reason": "tool"}),
+        ("ocr.stop", {"reason": "tool"}),
+    ],
+    "stt_start": lambda args, ctx: [
+        (
+            "stt_assist.start" if getattr(ctx, "assist_mode", False) else "stt.start",
+            {"reason": "tool"},
+        )
+    ],
+    "stt_stop": lambda args, ctx: [("stt.stop", {"reason": "tool"})],
+    "ocr_start": lambda args, ctx: [
+        (
+            "ocr_assist.start" if getattr(ctx, "assist_mode", False) else "ocr.start",
+            {"reason": "tool"},
+        )
+    ],
+    "ocr_stop": lambda args, ctx: [("ocr.stop", {"reason": "tool"})],
+}
+
+
+def _validate(name: str, args: Dict[str, Any]):
+    schema = SCHEMAS.get(name, {"type": "object"})
+    if jsonschema is None:
+        return
+    jsonschema.validate(args, schema)
+
+
+async def handle_tool_calls(tool_calls: List[Dict[str, Any]], ctx, bus) -> None:
+    """Validate and route tool calls to the event bus."""
+    for tc in tool_calls or []:
+        if not isinstance(tc, dict):
+            continue
+        func = tc.get("function", tc)
+        name = func.get("name")
+        raw_args = func.get("arguments", func.get("args") or {})
+        if isinstance(raw_args, str):
+            try:
+                args = json.loads(raw_args or "{}")
+            except Exception:
+                logger.warning(f"[tool-gw] invalid JSON args for {name}")
+                args = {}
+        else:
+            args = raw_args or {}
+
+        _validate(name, args)
+        route = TOOL_ROUTES.get(name)
+        if not route:
+            logger.warning(f"[tool-gw] no route for {name}")
+            continue
+
+        events = route(args, ctx)
+        corr = tc.get("correlation_id") or str(uuid.uuid4())
+        idem = tc.get("idempotency_key")
+        priority = tc.get("priority", 2)
+        now = time.time()
+        for etype, payload in events:
+            payload = dict(payload)
+            payload.update({"ts": now, "correlation_id": corr, "tool": name})
+            if idem:
+                payload["idempotency_key"] = idem
+            await bus.publish(
+                Event(
+                    type=etype,
+                    payload=payload,
+                    priority=priority,
+                    source="tool-gw",
+                    timestamp=now,
+                )
+            )
+
+
+async def process_response(resp: Dict[str, Any], ctx, bus) -> None:
+    """Handle LLM response dict with optional fallback for legacy JSON."""
+    tool_calls = resp.get("tool_calls")
+    if not tool_calls and resp.get("content"):
+        try:
+            parsed = json.loads(resp["content"])
+        except Exception:
+            return
+        if "tool_calls" in parsed:
+            logger.warning("[tool-gw] deprecated JSON content tool call path")
+            tool_calls = parsed.get("tool_calls")
+    if tool_calls:
+        await handle_tool_calls(tool_calls, ctx, bus)

--- a/prompts/tool_system_qwen.txt
+++ b/prompts/tool_system_qwen.txt
@@ -1,0 +1,20 @@
+행동이 필요할 땐 반드시 tool_calls로만 응답하라. 자연어 서술 금지.
+제공된 tools 중 알맞은 함수 하나만 호출하라. 인자는 JSON 스키마를 엄격히 지켜라.
+호출이 불가하면 빈 객체 인자로 합리적 기본값으로 호출하라.
+
+"보조"나 "어시스트"가 포함되지 않으면 보조용 툴을 호출하지 말라.
+"캡쳐해줘" 요청은 항상 ocr_capture를 사용하라.
+
+예시:
+<|user|>캡쳐해줘
+<|assistant|>{"tool_calls":[{"type":"function","function":{"name":"ocr_capture","arguments":"{}"}}]}
+<|user|>음성 받아줘
+<|assistant|>{"tool_calls":[{"type":"function","function":{"name":"stt_start","arguments":"{}"}}]}
+<|user|>STT 보조 켜줘
+<|assistant|>{"tool_calls":[{"type":"function","function":{"name":"stt_assist_start","arguments":"{}"}}]}
+<|user|>OCR 켜줘
+<|assistant|>{"tool_calls":[{"type":"function","function":{"name":"ocr_start","arguments":"{}"}}]}
+<|user|>보조모드 켜줘
+<|assistant|>{"tool_calls":[{"type":"function","function":{"name":"assist_on","arguments":"{}"}}]}
+<|user|>보조 끄기
+<|assistant|>{"tool_calls":[{"type":"function","function":{"name":"assist_off","arguments":"{}"}}]}

--- a/schemas/tool_calls.json
+++ b/schemas/tool_calls.json
@@ -1,0 +1,72 @@
+[
+  {
+    "type": "function",
+    "function": {
+      "name": "stt_assist_start",
+      "description": "Start STT Assist overlay",
+      "parameters": { "type": "object", "properties": {}, "additionalProperties": false }
+    }
+  },
+  {
+    "type": "function",
+    "function": {
+      "name": "ocr_capture",
+      "description": "Trigger OCR capture via assist overlay",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "region": { "type": "string", "description": "optional screen region id" }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  {
+    "type": "function",
+    "function": {
+      "name": "assist_on",
+      "description": "Enable assist mode without starting tools",
+      "parameters": { "type": "object", "properties": {}, "additionalProperties": false }
+    }
+  },
+  {
+    "type": "function",
+    "function": {
+      "name": "assist_off",
+      "description": "Stop all assist features",
+      "parameters": { "type": "object", "properties": {}, "additionalProperties": false }
+    }
+  },
+  {
+    "type": "function",
+    "function": {
+      "name": "stt_start",
+      "description": "Start STT in normal mode",
+      "parameters": { "type": "object", "properties": {}, "additionalProperties": false }
+    }
+  },
+  {
+    "type": "function",
+    "function": {
+      "name": "stt_stop",
+      "description": "Stop STT",
+      "parameters": { "type": "object", "properties": {}, "additionalProperties": false }
+    }
+  },
+  {
+    "type": "function",
+    "function": {
+      "name": "ocr_start",
+      "description": "Start OCR in normal mode",
+      "parameters": { "type": "object", "properties": {}, "additionalProperties": false }
+    }
+  },
+  {
+    "type": "function",
+    "function": {
+      "name": "ocr_stop",
+      "description": "Stop OCR",
+      "parameters": { "type": "object", "properties": {}, "additionalProperties": false }
+    }
+  }
+]

--- a/tests/test_tool_gateway.py
+++ b/tests/test_tool_gateway.py
@@ -1,0 +1,101 @@
+import asyncio
+from types import SimpleNamespace
+
+from agent import tool_gateway
+from agent.tool_gateway import handle_tool_calls
+
+
+class DummyBus:
+    def __init__(self):
+        self.events = []
+
+    async def publish(self, e):
+        self.events.append(e)
+
+
+def test_tool_gateway_routes_events():
+    bus = DummyBus()
+    ctx = SimpleNamespace(assist_mode=False)
+    tool_calls = [
+        {"function": {"name": "assist_on", "arguments": "{}"}},
+        {"idempotency_key": "abc", "function": {"name": "stt_assist_start", "arguments": "{}"}},
+        {"function": {"name": "ocr_capture", "arguments": "{\"region\": \"full\"}"}},
+        {"function": {"name": "assist_off", "arguments": "{}"}},
+    ]
+    asyncio.run(handle_tool_calls(tool_calls, ctx, bus))
+    types = [e.type for e in bus.events]
+    assert types == [
+        "assist.on",
+        "assist.on",
+        "stt_assist.start",
+        "ocr_assist.start",
+        "assist.off",
+        "stt.stop",
+        "ocr.stop",
+    ]
+    corr = bus.events[1].payload["correlation_id"]
+    assert corr == bus.events[2].payload["correlation_id"]
+    assert bus.events[1].payload["idempotency_key"] == "abc"
+
+
+def test_tool_gateway_basic_stt_ocr():
+    bus = DummyBus()
+    ctx = SimpleNamespace(assist_mode=False)
+    tool_calls = [
+        {"function": {"name": "stt_start", "arguments": "{}"}},
+        {"function": {"name": "ocr_start", "arguments": "{}"}},
+        {"function": {"name": "stt_stop", "arguments": "{}"}},
+        {"function": {"name": "ocr_stop", "arguments": "{}"}},
+    ]
+    asyncio.run(handle_tool_calls(tool_calls, ctx, bus))
+    assert [e.type for e in bus.events] == [
+        "stt.start",
+        "ocr.start",
+        "stt.stop",
+        "ocr.stop",
+    ]
+
+
+def test_tool_schemas_loaded():
+    names = {t["function"]["name"] for t in tool_gateway.TOOLS}
+    assert {
+        "stt_assist_start",
+        "ocr_capture",
+        "assist_on",
+        "assist_off",
+        "stt_start",
+        "stt_stop",
+        "ocr_start",
+        "ocr_stop",
+    }.issubset(names)
+    assert tool_gateway.SCHEMAS["ocr_capture"]["properties"]["region"]["type"] == "string"
+
+
+def test_ocr_capture_always_assist():
+    bus = DummyBus()
+    ctx = SimpleNamespace(assist_mode=False)
+    tool_calls = [{"function": {"name": "ocr_capture", "arguments": "{}"}}]
+    asyncio.run(handle_tool_calls(tool_calls, ctx, bus))
+    assert [e.type for e in bus.events] == ["ocr_assist.start"]
+
+
+def test_stt_ocr_start_assist_mode():
+    bus = DummyBus()
+    ctx = SimpleNamespace(assist_mode=True)
+    tool_calls = [
+        {"function": {"name": "stt_start", "arguments": "{}"}},
+        {"function": {"name": "ocr_start", "arguments": "{}"}},
+    ]
+    asyncio.run(handle_tool_calls(tool_calls, ctx, bus))
+    assert [e.type for e in bus.events] == [
+        "stt_assist.start",
+        "ocr_assist.start",
+    ]
+
+
+def test_assist_on_routes():
+    bus = DummyBus()
+    ctx = SimpleNamespace(assist_mode=False)
+    tool_calls = [{"function": {"name": "assist_on", "arguments": "{}"}}]
+    asyncio.run(handle_tool_calls(tool_calls, ctx, bus))
+    assert [e.type for e in bus.events] == ["assist.on"]


### PR DESCRIPTION
## Summary
- extend tool call schema and gateway with `assist_on` and context-aware routing so STT/OCR start use assist variants when assist mode is active
- default `ocr_capture` to the OCR assist overlay and expand Qwen prompt to avoid assist tools unless explicitly requested
- add tests for assist mode routing and new tool schema

## Testing
- `pip install -r requirements.txt` (fails: Could not find a version that satisfies the requirement torch>=2.1.0)
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4e7f6ac208333b6d992c1174101cf