### PR TITLE
feat: add assist STT and OCR plugins

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -64,3 +64,4 @@
 - Added assist_on tool and rerouted stt/ocr_start to assist events when assist mode is active; ocr_capture now always starts OCR assist and prompt examples teach models to avoid assist tools unless explicitly requested.
 
 - Tool definitions converted to snake_case and expanded to include assist_on/off and start/stop handlers for STT/OCR in both normal and assist modes; configs, prompts, and overlay mappings updated for full tool_call compatibility.
+- Added stt_assist and ocr_assist plugins so assist-mode transcripts bypass default cleanup and are processed separately; future integration with wake-word triggers and advanced OCR/STT features still needed.

--- a/agent/plugins/ocr_assist_plugin.py
+++ b/agent/plugins/ocr_assist_plugin.py
@@ -1,0 +1,16 @@
+from . import BasePlugin
+from loguru import logger
+
+class OCRAssistPlugin(BasePlugin):
+    """Cleanup for OCR Assist text."""
+    name = "ocr_assist"
+    handles = ["ocr.text"]
+
+    async def handle(self, event):
+        if not event.payload.get("assist"):
+            return
+        text = event.payload.get("text", "")
+        text = text.replace("\u200b", "").strip()
+        event.payload["text"] = text
+        await self.ctx.bus.publish(event)
+        logger.debug(f"[{self.name}] cleaned and republished ocr.text")

--- a/agent/plugins/ocr_plugin.py
+++ b/agent/plugins/ocr_plugin.py
@@ -6,6 +6,10 @@ class OCRPlugin(BasePlugin):
     handles = ["ocr.text"]
 
     async def handle(self, event):
+        # Skip assist-mode OCR; handled by ocr_assist plugin
+        if event.payload.get("assist"):
+            return
+
         text = event.payload.get("text", "")
         # 간단한 노이즈 제거
         text = text.replace("\u200b", "").strip()

--- a/agent/plugins/stt_assist_plugin.py
+++ b/agent/plugins/stt_assist_plugin.py
@@ -1,0 +1,19 @@
+from . import BasePlugin
+from loguru import logger
+
+class STTAssistPlugin(BasePlugin):
+    """Cleanup for STT Assist transcripts."""
+    name = "stt_assist"
+    handles = ["stt.text"]
+
+    async def handle(self, event):
+        if not event.payload.get("assist"):
+            return
+        text = event.payload.get("text", "")
+        parts = [p.strip() for p in text.split()]
+        dedup = []
+        for p in parts:
+            if not dedup or dedup[-1] != p:
+                dedup.append(p)
+        event.payload["text"] = " ".join(dedup)
+        logger.debug(f"[{self.name}] cleaned stt.text")

--- a/agent/plugins/stt_plugin.py
+++ b/agent/plugins/stt_plugin.py
@@ -6,6 +6,10 @@ class STTPlugin(BasePlugin):
     handles = ["stt.text"]
 
     async def handle(self, event):
+        # Skip assist-mode transcripts; handled by stt_assist plugin
+        if event.payload.get("assist"):
+            return
+
         text = event.payload.get("text", "")
         # 반복 제거 (예: "I'm going to do it" 반복 등)
         parts = [p.strip() for p in text.split()]


### PR DESCRIPTION
## Summary
- handle assist-mode transcripts with new `stt_assist` and `ocr_assist` plugins
- skip assist events in default STT/OCR cleanup to avoid duplicate processing
- record addition in Agent memory

## Testing
- ⚠️ `pip install -r requirements.txt` (torch>=2.1.0 not found)
- ⚠️ `ruff check .` (382 errors)
- ✅ `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4f380a8c483339143cfffbb043ba7