### PR TITLE
Integrate assist tools with Luna bridge and orchestrator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,8 @@ test: pytest -q
 - Do not leak secrets.
 - Ask for approval before sensitive actions.
 - Keep changes minimal and documented.
+- All new tools must include the Luna Agent bridge for event posting (see `STT/VSRG-Ts-to-kr.py`).
+- All new tools must be integrated into the Orchestrator; verify this integration whenever a tool is added.
 
 # Commands
 - Run tests: pytest -q

--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -66,3 +66,4 @@
 - Tool definitions converted to snake_case and expanded to include assist_on/off and start/stop handlers for STT/OCR in both normal and assist modes; configs, prompts, and overlay mappings updated for full tool_call compatibility.
 - Added mictrans and capture_assist plugins so assist-mode transcripts bypass default cleanup and are processed separately; future integration with wake-word triggers and advanced OCR/STT features still needed.
 - Renamed assist tools: STT assist -> MicTrans and OCR assist -> Capture Assist; updated configs, tool calls, and tests.
+- MicTrans and Capture Assist now include Luna Agent bridge and send overlay events via the orchestrator; MicTrans also emits a mictrans.started event when listening. Update AGENTS.md to require Luna bridge and orchestrator integration for all new tools. Wake-word triggers and broader assist features remain.

--- a/Capture-assist/capture_assist.py
+++ b/Capture-assist/capture_assist.py
@@ -20,14 +20,18 @@ import yaml
 import numpy as np
 from PIL import Image
 from mss import mss
-import requests
+import requests as _rq
 from tools.tts_espeak import speak
+
+# Backwards-compatibility alias for tests expecting module-level `requests`
+requests = _rq
 
 try:  # EasyOCR downloads models on first use
     import easyocr
 except Exception:  # pragma: no cover - runtime dependency
     easyocr = None
 
+# ---- Luna Agent bridge (공통) ----
 _EVENT_URL = (
     os.environ.get("EVENT_URL")
     or os.environ.get("AGENT_EVENT_URL")
@@ -42,7 +46,7 @@ def _post_event(_type: str, _payload: dict, _prio: int = 5) -> None:
         headers = {"Content-Type": "application/json"}
         if _EVENT_KEY:
             headers["X-Agent-Key"] = _EVENT_KEY
-        requests.post(
+        _rq.post(
             _EVENT_URL,
             json={"type": _type, "payload": _payload, "priority": _prio},
             headers=headers,
@@ -52,9 +56,19 @@ def _post_event(_type: str, _payload: dict, _prio: int = 5) -> None:
         pass
 
 
+def _overlay_toast(message: str, title: str = "Assist-Capture") -> None:
+    """Mirror messages to Lunar Bridge overlay as toasts."""
+    message = (message or "").strip()
+    if not message:
+        return
+    if len(message) > 240:
+        message = message[:239] + "…"
+    _post_event("overlay.toast", {"title": title, "text": message})
+
+
 def _notify(msg: str) -> None:
     """Display a toast notification locally and via overlay."""
-    _post_event("overlay.toast", {"title": "Assist-Capture", "text": msg})
+    _overlay_toast(msg)
     try:
         from agent.sinks import toast_notify
 
@@ -97,7 +111,7 @@ def _refine_with_jan(text: str) -> str:
         "reasoning": {"effort": "high"},
     }
     try:
-        r = requests.post(
+        r = _rq.post(
             f"{endpoint}/chat/completions", headers=headers, json=payload, timeout=10
         )
         r.raise_for_status()

--- a/Mic-trans-assist/mictrans.py
+++ b/Mic-trans-assist/mictrans.py
@@ -46,7 +46,10 @@ try:  # faster-whisper is optional for import-time
 except Exception:  # pragma: no cover - handled gracefully
     WhisperModel = None
 
-import requests
+import requests as _rq
+
+# Backwards-compatibility alias for tests expecting module-level `requests`
+requests = _rq
 import importlib.util
 import pathlib
 import sys
@@ -68,6 +71,7 @@ except Exception:  # pragma: no cover - script execution
     spec.loader.exec_module(cmd_mod)
     detect_command = cmd_mod.detect_command
 
+# ---- Luna Agent bridge (공통) ----
 _EVENT_URL = (
     os.environ.get("EVENT_URL")
     or os.environ.get("AGENT_EVENT_URL")
@@ -83,7 +87,7 @@ def _post_event(_type: str, _payload: dict, _prio: int = 5) -> None:
         headers = {"Content-Type": "application/json"}
         if _EVENT_KEY:
             headers["X-Agent-Key"] = _EVENT_KEY
-        requests.post(
+        _rq.post(
             _EVENT_URL,
             json={"type": _type, "payload": _payload, "priority": _prio},
             headers=headers,
@@ -93,10 +97,20 @@ def _post_event(_type: str, _payload: dict, _prio: int = 5) -> None:
         pass
 
 
+def _overlay_toast(message: str, title: str = "Assist-MicTrans") -> None:
+    """Mirror messages to Lunar Bridge overlay as toasts."""
+    message = (message or "").strip()
+    if not message:
+        return
+    if len(message) > 240:
+        message = message[:239] + "…"
+    _post_event("overlay.toast", {"title": title, "text": message})
+
+
 def _notify_listening() -> None:
     """Toast notification that MicTrans is listening."""
     msg = "마이크 청취 중"
-    _post_event("overlay.toast", {"title": "Assist-MicTrans", "text": msg})
+    _overlay_toast(msg)
     try:
         from agent.sinks import toast_notify
 
@@ -232,7 +246,7 @@ class AssistTranscriber:
             "max_tokens": cfg.get("max_new_tokens", 512),
         }
         try:
-            r = requests.post(
+            r = _rq.post(
                 f"{endpoint}/chat/completions",
                 headers=headers,
                 json=payload,
@@ -466,6 +480,7 @@ def run(cfg: AssistConfig) -> None:
         device=device,
     ):
         _notify_listening()
+        _post_event("mictrans.started", {"ts": time.time()})
         threading.Timer(600, _notify_listening).start()
         threading.Thread(target=worker, daemon=True).start()
         ui.loop()


### PR DESCRIPTION
## Summary
- add Luna Agent bridge to MicTrans and emit `mictrans.started` events
- add Luna Agent bridge to Capture Assist
- document that new tools must include Luna Agent bridge and be wired into the Orchestrator

## Testing
- `pip install -r requirements.txt` *(fails: No matching distribution found for torch>=2.1.0)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5528961c8833385b196e2378b6179