### PR TITLE
Unify MicTrans voice input and Capture Assist across modes

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -67,3 +67,5 @@
 - Added mictrans and capture_assist plugins so assist-mode transcripts bypass default cleanup and are processed separately; future integration with wake-word triggers and advanced OCR/STT features still needed.
 - Renamed assist tools: STT assist -> MicTrans and OCR assist -> Capture Assist; updated configs, tool calls, and tests.
 - MicTrans and Capture Assist now include Luna Agent bridge and send overlay events via the orchestrator; MicTrans also emits a mictrans.started event when listening. Update AGENTS.md to require Luna bridge and orchestrator integration for all new tools. Wake-word triggers and broader assist features remain.
+
+- Voice input and capture commands unified so MicTrans handles all voice input and Capture Assist performs screenshot OCR with a five-second delay in both modes; server, command router, tool gateway, and docs updated accordingly.

--- a/agent/server.py
+++ b/agent/server.py
@@ -118,8 +118,8 @@ def create_app(ctx, plugins=None):
                     if app.state.stt_proc and app.state.stt_proc.poll() is None:
                         logger.info("[stt] already running")
                     else:
-                        key = "mictrans.start" if ev.type == "mictrans.start" or app.state.assist_mode else "stt.start"
-                        app.state.stt_proc = _spawn_tool(getattr(ctx, "config", {}), key)
+                        # MicTrans handles voice input for both normal and assist modes
+                        app.state.stt_proc = _spawn_tool(getattr(ctx, "config", {}), "mictrans.start")
                 elif ev.type in ("stt.stop", "mictrans.stop"):
                     if app.state.assist_mode and ev.type != "mictrans.stop":
                         logger.info("[stt] stop ignored in assist mode")
@@ -141,8 +141,8 @@ def create_app(ctx, plugins=None):
                     if app.state.ocr_proc and app.state.ocr_proc.poll() is None:
                         logger.info("[ocr] already running")
                     else:
-                        key = "capture_assist.start" if ev.type == "capture_assist.start" or app.state.assist_mode else "ocr.start"
-                        app.state.ocr_proc = _spawn_tool(getattr(ctx, "config", {}), key)
+                        # Capture Assist provides delayed capture in all modes
+                        app.state.ocr_proc = _spawn_tool(getattr(ctx, "config", {}), "capture_assist.start")
                 elif ev.type in ("ocr.stop", "capture_assist.stop"):
                     await _terminate_proc(getattr(app.state, "ocr_proc", None), name="ocr", timeout=3.0)
                     app.state.ocr_proc = None
@@ -186,7 +186,8 @@ def create_app(ctx, plugins=None):
                     app.state.assist_task = None
                     await _terminate_proc(getattr(app.state, "stt_proc", None), name="stt", timeout=3.0)
                     await _terminate_proc(getattr(app.state, "ocr_proc", None), name="ocr", timeout=3.0)
-                    app.state.stt_proc = _spawn_tool(getattr(ctx, "config", {}), "stt.start")
+                    # Resume voice input with MicTrans when leaving assist mode
+                    app.state.stt_proc = _spawn_tool(getattr(ctx, "config", {}), "mictrans.start")
                     app.state.ocr_proc = None
 
             ctx.bus.subscribe("assist.", _assist_handler)
@@ -213,10 +214,8 @@ def create_app(ctx, plugins=None):
 
                 # 라우팅
                 if c == "capture":
-                    # assist 모드면 capture_assist.start, 아니면 ocr.start
-                    etype = "capture_assist.start" if app.state.assist_mode else "ocr.start"
                     await ctx.bus.publish(Event(
-                        type=etype,
+                        type="capture_assist.start",
                         payload={"reason": "voice_cmd", "cmd": c, "ts": ts},
                         priority=2,
                         source="router",
@@ -239,8 +238,8 @@ def create_app(ctx, plugins=None):
                         source="router",
                         timestamp=_t.time(),
                     ))
-                    await ctx.bus.publish(Event(type="ocr.stop", payload={}, priority=3, source="router", timestamp=_t.time()))
-                    await ctx.bus.publish(Event(type="stt.stop", payload={}, priority=3, source="router", timestamp=_t.time()))
+                    await ctx.bus.publish(Event(type="capture_assist.stop", payload={}, priority=3, source="router", timestamp=_t.time()))
+                    await ctx.bus.publish(Event(type="mictrans.stop", payload={}, priority=3, source="router", timestamp=_t.time()))
                 # 필요하면 여기서 summarize/translate 등도 매핑
 
             ctx.bus.subscribe("cmd.", _cmd_handler)

--- a/agent/tool_gateway.py
+++ b/agent/tool_gateway.py
@@ -25,7 +25,6 @@ SCHEMAS: Dict[str, Dict[str, Any]] = {
 # Tool name to event mapping
 TOOL_ROUTES = {
       "mictrans_start": lambda args, ctx: [
-          ("assist.on", {"reason": "tool", "args": args}),
           ("mictrans.start", {"reason": "tool"}),
       ],
       "mictrans_stop": lambda args, ctx: [
@@ -43,23 +42,13 @@ TOOL_ROUTES = {
     "assist_on": lambda args, ctx: [("assist.on", {"reason": "tool"})],
     "assist_off": lambda args, ctx: [
         ("assist.off", {"reason": "tool"}),
-        ("stt.stop", {"reason": "tool"}),
-        ("ocr.stop", {"reason": "tool"}),
+        ("mictrans.stop", {"reason": "tool"}),
+        ("capture_assist.stop", {"reason": "tool"}),
     ],
-    "stt_start": lambda args, ctx: [
-          (
-              "mictrans.start" if getattr(ctx, "assist_mode", False) else "stt.start",
-              {"reason": "tool"},
-          )
-    ],
-    "stt_stop": lambda args, ctx: [("stt.stop", {"reason": "tool"})],
-    "ocr_start": lambda args, ctx: [
-          (
-              "capture_assist.start" if getattr(ctx, "assist_mode", False) else "ocr.start",
-              {"reason": "tool"},
-          )
-    ],
-    "ocr_stop": lambda args, ctx: [("ocr.stop", {"reason": "tool"})],
+    "stt_start": lambda args, ctx: [("mictrans.start", {"reason": "tool"})],
+    "stt_stop": lambda args, ctx: [("mictrans.stop", {"reason": "tool"})],
+    "ocr_start": lambda args, ctx: [("capture_assist.start", {"reason": "tool"})],
+    "ocr_stop": lambda args, ctx: [("capture_assist.stop", {"reason": "tool"})],
 }
 
 

--- a/docs/ACCESSIBILITY_MODE.md
+++ b/docs/ACCESSIBILITY_MODE.md
@@ -23,10 +23,10 @@ contributors.
 - **Core Modules** – pseudocode skeletons under `src/core/` outline stable ID
   generation, ROI‑OCR, ranking, rule-based NLU, two‑stage runner, barge‑in and
   preserve‑lock logic.
-- **MicTrans** – `Mic-trans-assist/mictrans.py` streams microphone audio through Whisper,
+- **MicTrans** – `Mic-trans-assist/mictrans.py` streams microphone audio for voice input,
   auto-selecting the default input device and posting `stt.text` events with
   an `assist` flag so the overlay labels them **Assist-MicTrans**.
-- **Capture Assist** – `Capture-assist/capture_assist.py` captures a screenshot, runs OCR, and
+- **Capture Assist** – `Capture-assist/capture_assist.py` waits five seconds, captures a screenshot, runs OCR, and
   emits `ocr.text` events marked `assist`, appearing as **Assist-Capture** on the
   overlay.
 - **Assist Commands** – `agent/plugins/assist_cmd_plugin.py` listens for

--- a/docs/ASSIST_COMMANDS.md
+++ b/docs/ASSIST_COMMANDS.md
@@ -3,8 +3,8 @@
 This document summarizes the assistive modules and the command plugin that react to speech in accessibility mode.
 
 ## MicTrans & Capture Assist
-- **MicTrans** (`Mic-trans-assist/mictrans.py`) captures microphone audio in real time and posts `stt.text` events with `assist: true`. The overlay labels these transcripts as **Assist-MicTrans**.
-- **Capture Assist** (`Capture-assist/capture_assist.py`) takes a screenshot, performs OCR, and emits `ocr.text` events marked with `assist: true`. The overlay displays the text as **Assist-Capture**.
+- **MicTrans** (`Mic-trans-assist/mictrans.py`) captures microphone audio as voice input and posts `stt.text` events with `assist: true`. The overlay labels these transcripts as **Assist-MicTrans**.
+- **Capture Assist** (`Capture-assist/capture_assist.py`) waits five seconds, takes a screenshot, performs OCR, and emits `ocr.text` events marked with `assist: true`. The overlay displays the text as **Assist-Capture**.
 
 ## Command Plugin
 `agent/plugins/assist_cmd_plugin.py` watches STT transcripts for the following Korean keywords and triggers the matching tools:

--- a/tests/test_cmd_router.py
+++ b/tests/test_cmd_router.py
@@ -17,14 +17,14 @@ async def dispatch_all(bus: EventBus):
                     await h(e)
 
 
-async def _run(ctx, subscribe_prefix):
+async def _run(ctx):
     app = create_app(ctx, plugins=[])
     events = []
     try:
         async with app.router.lifespan_context(app):
             async def collect(ev):
                 events.append(ev.type)
-            ctx.bus.subscribe(subscribe_prefix, collect)
+            ctx.bus.subscribe("capture_assist.", collect)
             handler = ctx.bus.subscribers["cmd.detected"][0]
             await handler(Event(type="cmd.detected", payload={"cmd": "capture"}))
             await dispatch_all(ctx.bus)
@@ -33,13 +33,13 @@ async def _run(ctx, subscribe_prefix):
     return events
 
 
-def test_cmd_detected_to_ocr():
+def test_cmd_detected_routes_to_capture_assist_normal():
     ctx = SimpleNamespace(config={}, bus=EventBus(dedup_window=0), assist_mode=False)
-    events = asyncio.run(_run(ctx, "ocr."))
-    assert events == ["ocr.start"]
+    events = asyncio.run(_run(ctx))
+    assert events == ["capture_assist.start"]
 
-def test_cmd_detected_to_capture_assist():
+def test_cmd_detected_routes_to_capture_assist_assist_mode():
     ctx = SimpleNamespace(config={}, bus=EventBus(dedup_window=0), assist_mode=True)
-    events = asyncio.run(_run(ctx, "capture_assist."))
+    events = asyncio.run(_run(ctx))
     assert events == ["capture_assist.start"]
 

--- a/tests/test_tool_gateway.py
+++ b/tests/test_tool_gateway.py
@@ -26,15 +26,12 @@ def test_tool_gateway_routes_events():
     types = [e.type for e in bus.events]
     assert types == [
         "assist.on",
-          "assist.on",
-          "mictrans.start",
-          "capture_assist.start",
+        "mictrans.start",
+        "capture_assist.start",
         "assist.off",
-        "stt.stop",
-        "ocr.stop",
+        "mictrans.stop",
+        "capture_assist.stop",
     ]
-    corr = bus.events[1].payload["correlation_id"]
-    assert corr == bus.events[2].payload["correlation_id"]
     assert bus.events[1].payload["idempotency_key"] == "abc"
 
 
@@ -49,10 +46,10 @@ def test_tool_gateway_basic_stt_ocr():
     ]
     asyncio.run(handle_tool_calls(tool_calls, ctx, bus))
     assert [e.type for e in bus.events] == [
-        "stt.start",
-        "ocr.start",
-        "stt.stop",
-        "ocr.stop",
+        "mictrans.start",
+        "capture_assist.start",
+        "mictrans.stop",
+        "capture_assist.stop",
     ]
 
 

--- a/tools/tool/assist_control.py
+++ b/tools/tool/assist_control.py
@@ -19,19 +19,21 @@ def _post(name: str) -> Dict[str, Any]:
 
 
 def stt_start(_: Dict[str, Any]) -> Dict[str, Any]:
-    return _post("stt.start")
+    # Alias to MicTrans voice input
+    return _post("mictrans.start")
 
 
 def stt_stop(_: Dict[str, Any]) -> Dict[str, Any]:
-    return _post("stt.stop")
+    return _post("mictrans.stop")
 
 
 def ocr_start(_: Dict[str, Any]) -> Dict[str, Any]:
-    return _post("ocr.start")
+    # Capture Assist handles OCR with a delay
+    return _post("capture_assist.start")
 
 
 def ocr_stop(_: Dict[str, Any]) -> Dict[str, Any]:
-    return _post("ocr.stop")
+    return _post("capture_assist.stop")
 
 
 def mictrans_start(_: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- Route both normal and assist mode voice input through MicTrans and screen capture through Capture Assist
- Update tool gateway, assist control functions, and documentation to reflect MicTrans as voice input and Capture Assist with 5‑second delay
- Adjust command router and tests so `capture` and `stt` paths consistently trigger Capture Assist and MicTrans

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement torch>=2.1.0)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b55a42bc188333aaa2052ee034081e