### PR TITLE
Add capture assist and mictrans plugins with tool bridges

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,3 +10,7 @@ test: pytest -q
 # Commands
 - Run tests: pytest -q
 - Lint (optional): ruff .
+
+# Tools
+- capture_assist → emits `capture_assist.text`
+- mictrans → emits `mictrans.text`

--- a/agent/plugins/capture_assist_plugin.py
+++ b/agent/plugins/capture_assist_plugin.py
@@ -1,0 +1,14 @@
+from . import BasePlugin
+from loguru import logger
+
+class CaptureAssistPlugin(BasePlugin):
+    """Normalize capture-assist text and republish for downstream handlers."""
+    name = "capture_assist_cleanup"
+    handles = ["capture_assist.text"]
+
+    async def handle(self, event):
+        text = event.payload.get("text", "").strip()
+        event.payload["text"] = text
+        # Republish so translator and others can consume
+        await self.ctx.bus.publish(event)
+        logger.debug(f"[{self.name}] cleaned and republished capture_assist.text")

--- a/agent/plugins/mictrans_plugin.py
+++ b/agent/plugins/mictrans_plugin.py
@@ -1,0 +1,12 @@
+from . import BasePlugin
+from loguru import logger
+
+class MicTransPlugin(BasePlugin):
+    """Clean microphone transcription text."""
+    name = "mictrans_cleanup"
+    handles = ["mictrans.text"]
+
+    async def handle(self, event):
+        text = event.payload.get("text", "")
+        event.payload["text"] = text.strip()
+        logger.debug(f"[{self.name}] cleaned mictrans.text")

--- a/agent/plugins/translator_plugin.py
+++ b/agent/plugins/translator_plugin.py
@@ -10,7 +10,15 @@ def strip_think(text: str) -> str:
 
 class TranslatorPlugin(BasePlugin):
     name = "translator"
-    handles = ["ocr.text", "stt.text", "discord.batch", "discord.text", "notif.batch"]
+    handles = [
+        "ocr.text",
+        "stt.text",
+        "discord.batch",
+        "discord.text",
+        "notif.batch",
+        "capture_assist.text",
+        "mictrans.text",
+    ]
 
     async def _translate_once(self, endpoint, model, api_key, text: str, target_lang: str) -> Optional[str]:
         headers = {"Content-Type": "application/json"}

--- a/tools/config/tools.yaml
+++ b/tools/config/tools.yaml
@@ -46,3 +46,29 @@ tools:
           type: string
           description: "오디오 파일 경로"
       required: [audio_path]
+
+  - name: capture_assist
+    module: tools.tool.capture_assist
+    class: CaptureAssist
+    enabled: true
+    desc: "보조 캡처 텍스트 전달"
+    input_schema:
+      type: object
+      properties:
+        text:
+          type: string
+          description: "전달할 텍스트"
+      required: [text]
+
+  - name: mictrans
+    module: tools.tool.mictrans
+    class: MicTrans
+    enabled: true
+    desc: "마이크 전사 텍스트 전달"
+    input_schema:
+      type: object
+      properties:
+        text:
+          type: string
+          description: "전사된 텍스트"
+      required: [text]

--- a/tools/tool/capture_assist.py
+++ b/tools/tool/capture_assist.py
@@ -1,0 +1,18 @@
+from typing import Dict, Any
+from .base import ToolPlugin, ToolContext
+
+class CaptureAssist(ToolPlugin):
+    """Forward capture assist text into the agent event bus."""
+    name = "capture_assist"
+    description = "Capture assist text forwarding"
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "text": {"type": "string", "description": "text to forward"},
+        },
+        "required": ["text"],
+    }
+
+    def run(self, args: Dict[str, Any], ctx: ToolContext) -> Dict[str, Any]:
+        ctx.event_bus("capture_assist.text", {"text": args["text"]})
+        return self.ok()

--- a/tools/tool/mictrans.py
+++ b/tools/tool/mictrans.py
@@ -1,0 +1,18 @@
+from typing import Dict, Any
+from .base import ToolPlugin, ToolContext
+
+class MicTrans(ToolPlugin):
+    """Forward microphone transcription text into the agent event bus."""
+    name = "mictrans"
+    description = "Mic transcription forwarding"
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "text": {"type": "string", "description": "transcribed text"},
+        },
+        "required": ["text"],
+    }
+
+    def run(self, args: Dict[str, Any], ctx: ToolContext) -> Dict[str, Any]:
+        ctx.event_bus("mictrans.text", {"text": args["text"]})
+        return self.ok()


### PR DESCRIPTION
## Summary
- add capture assist and mictrans cleanup plugins emitting `capture_assist.text` and `mictrans.text`
- wire translator plugin to new event types and expose tool bridges
- document and register tools for event bus forwarding

## Testing
- `pip install -r requirements.txt || true`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b55e037ed083338d85e6cc913fa3e1