### PR TITLE
feat: route capture assist and mictrans events

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ test: pytest -q
 - Keep changes minimal and documented.
 - All new tools must include the Luna Agent bridge for event posting (see `STT/VSRG-Ts-to-kr.py`).
 - All new tools must be integrated into the Orchestrator; verify this integration whenever a tool is added.
+- Use unique event names for new tools (e.g., `capture_assist.text`, `mictrans.text`) to avoid argument collisions.
 
 # Commands
 - Run tests: pytest -q

--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -69,3 +69,4 @@
 - MicTrans and Capture Assist now include Luna Agent bridge and send overlay events via the orchestrator; MicTrans also emits a mictrans.started event when listening. Update AGENTS.md to require Luna bridge and orchestrator integration for all new tools. Wake-word triggers and broader assist features remain.
 
 - Voice input and capture commands unified so MicTrans handles all voice input and Capture Assist performs screenshot OCR with a five-second delay in both modes; server, command router, tool gateway, and docs updated accordingly.
+- Capture Assist and MicTrans now emit `capture_assist.text` and `mictrans.text` events, translator plugin republishes translations via `translator.text` and overlay toasts. Tool list, docs, and AGENTS.md updated; broader assist integration still pending.

--- a/Capture-assist/capture_assist.py
+++ b/Capture-assist/capture_assist.py
@@ -206,7 +206,7 @@ def main() -> None:
     text = _run_ocr(img, cfg)
     text = _refine_with_jan(text)
     if text:
-        _post_event("ocr.text", {"text": text, "source": "easyocr_assist", "assist": True})
+        _post_event("capture_assist.text", {"text": text, "source": "easyocr_assist", "assist": True})
         print(text)
         if cfg.announce_text:
             speak(cfg.announce_text, lang="ko")

--- a/Mic-trans-assist/mictrans.py
+++ b/Mic-trans-assist/mictrans.py
@@ -295,7 +295,7 @@ class AssistTranscriber:
                 "stt_model": getattr(self.model, "model_size", "unknown"),
                 "assist": True,
             }
-            self.event_func("stt.text", payload)
+            self.event_func("mictrans.text", payload)
             if self.ui:
                 self.ui.push(text)
             cmd = detect_command(text, self.cfg)

--- a/Overlay/agent/plugins/translator_plugin.py
+++ b/Overlay/agent/plugins/translator_plugin.py
@@ -2,6 +2,7 @@ from . import BasePlugin
 from loguru import logger
 from typing import Optional
 import httpx, re, asyncio
+from ..schemas import Event
 
 THINK_RE = re.compile(r"<think>.*?</think>\s*", re.DOTALL)
 
@@ -10,7 +11,15 @@ def strip_think(text: str) -> str:
 
 class TranslatorPlugin(BasePlugin):
     name = "translator"
-    handles = ["ocr.text", "stt.text", "discord.batch", "discord.text", "notif.batch"]
+    handles = [
+        "ocr.text",
+        "stt.text",
+        "discord.batch",
+        "discord.text",
+        "notif.batch",
+        "capture_assist.text",
+        "mictrans.text",
+    ]
 
     async def _translate_once(self, endpoint, model, api_key, text: str, target_lang: str) -> Optional[str]:
         headers = {"Content-Type": "application/json"}
@@ -101,7 +110,7 @@ class TranslatorPlugin(BasePlugin):
         if not text and not existing:
             return
 
-        if event.type == "stt.text" and payload.get("source") == "assist":
+        if event.type in ("stt.text", "mictrans.text") and payload.get("source") == "assist":
             kw = self.ctx.config.get("stt", {}).get("llm_keyword")
             if kw and kw not in text:
                 return
@@ -125,5 +134,16 @@ class TranslatorPlugin(BasePlugin):
 
         msg = f"[{self.name}] {event.type} → 번역 완료: {translated[:180]}..."
         self.ctx.sinks.write_log(msg, self.ctx.config["sinks"].get("log_file"))
+        event.payload["translation"] = translated
+        await self.ctx.bus.publish(
+            Event(type="translator.text", payload={"text": translated, "source": event.type})
+        )
+        await self.ctx.bus.publish(
+            Event(
+                type="overlay.toast",
+                payload={"title": "번역 완료", "text": translated[:64]},
+            )
+        )
         if self.ctx.config["sinks"].get("toast", True):
             self.ctx.sinks.toast_notify("번역 완료", translated[:64])
+

--- a/Overlay/overlay_app.py
+++ b/Overlay/overlay_app.py
@@ -102,9 +102,9 @@ class EventHandler:
             
             # 이벤트 타입별 처리
             success = False
-            if event_type.startswith("stt."):
+            if event_type.startswith("stt.") or event_type.startswith("mictrans."):
                 success = self._handle_stt(payload)
-            elif event_type.startswith("ocr."):
+            elif event_type.startswith("ocr.") or event_type.startswith("capture_assist."):
                 success = self._handle_ocr(payload)
             elif event_type.startswith("web.search"):
                 success = self._handle_web_search(payload)

--- a/Overlay/overlay_app_enhanced.py
+++ b/Overlay/overlay_app_enhanced.py
@@ -108,9 +108,9 @@ class EnhancedEventHandler:
             
             # 2. 기존 내장 처리기로 fallback
             success = False
-            if event_type.startswith("stt."):
+            if event_type.startswith("stt.") or event_type.startswith("mictrans."):
                 success = self._handle_stt(payload)
-            elif event_type.startswith("ocr."):
+            elif event_type.startswith("ocr.") or event_type.startswith("capture_assist."):
                 success = self._handle_ocr(payload)
             elif event_type.startswith("web.search"):
                 success = self._handle_web_search(payload)

--- a/agent/plugins/capture_assist_plugin.py
+++ b/agent/plugins/capture_assist_plugin.py
@@ -4,7 +4,7 @@ from loguru import logger
 class CaptureAssistPlugin(BasePlugin):
     """Cleanup for Capture Assist text."""
     name = "capture_assist"
-    handles = ["ocr.text"]
+    handles = ["capture_assist.text"]
 
     async def handle(self, event):
         if not event.payload.get("assist"):
@@ -13,4 +13,4 @@ class CaptureAssistPlugin(BasePlugin):
         text = text.replace("\u200b", "").strip()
         event.payload["text"] = text
         await self.ctx.bus.publish(event)
-        logger.debug(f"[{self.name}] cleaned and republished ocr.text")
+        logger.debug(f"[{self.name}] cleaned and republished capture_assist.text")

--- a/agent/plugins/mictrans_plugin.py
+++ b/agent/plugins/mictrans_plugin.py
@@ -4,7 +4,7 @@ from loguru import logger
 class MicTransPlugin(BasePlugin):
     """Cleanup for MicTrans transcripts."""
     name = "mictrans"
-    handles = ["stt.text"]
+    handles = ["mictrans.text"]
 
     async def handle(self, event):
         if not event.payload.get("assist"):
@@ -16,4 +16,5 @@ class MicTransPlugin(BasePlugin):
             if not dedup or dedup[-1] != p:
                 dedup.append(p)
         event.payload["text"] = " ".join(dedup)
-        logger.debug(f"[{self.name}] cleaned stt.text")
+        await self.ctx.bus.publish(event)
+        logger.debug(f"[{self.name}] cleaned and republished mictrans.text")

--- a/agent/plugins/translator_plugin.py
+++ b/agent/plugins/translator_plugin.py
@@ -2,6 +2,7 @@ from . import BasePlugin
 from loguru import logger
 from typing import Optional
 import httpx, re, asyncio
+from ..schemas import Event
 
 THINK_RE = re.compile(r"<think>.*?</think>\s*", re.DOTALL)
 
@@ -10,7 +11,15 @@ def strip_think(text: str) -> str:
 
 class TranslatorPlugin(BasePlugin):
     name = "translator"
-    handles = ["ocr.text", "stt.text", "discord.batch", "discord.text", "notif.batch"]
+    handles = [
+        "ocr.text",
+        "stt.text",
+        "discord.batch",
+        "discord.text",
+        "notif.batch",
+        "capture_assist.text",
+        "mictrans.text",
+    ]
 
     async def _translate_once(self, endpoint, model, api_key, text: str, target_lang: str) -> Optional[str]:
         headers = {"Content-Type": "application/json"}
@@ -121,5 +130,15 @@ class TranslatorPlugin(BasePlugin):
 
         msg = f"[{self.name}] {event.type} → 번역 완료: {translated[:180]}..."
         self.ctx.sinks.write_log(msg, self.ctx.config["sinks"].get("log_file"))
+        event.payload["translation"] = translated
+        await self.ctx.bus.publish(
+            Event(type="translator.text", payload={"text": translated, "source": event.type})
+        )
+        await self.ctx.bus.publish(
+            Event(
+                type="overlay.toast",
+                payload={"title": "번역 완료", "text": translated[:64]},
+            )
+        )
         if self.ctx.config["sinks"].get("toast", True):
             self.ctx.sinks.toast_notify("번역 완료", translated[:64])

--- a/docs/ACCESSIBILITY_MODE.md
+++ b/docs/ACCESSIBILITY_MODE.md
@@ -24,10 +24,10 @@ contributors.
   generation, ROI‑OCR, ranking, rule-based NLU, two‑stage runner, barge‑in and
   preserve‑lock logic.
 - **MicTrans** – `Mic-trans-assist/mictrans.py` streams microphone audio for voice input,
-  auto-selecting the default input device and posting `stt.text` events with
+  auto-selecting the default input device and posting `mictrans.text` events with
   an `assist` flag so the overlay labels them **Assist-MicTrans**.
 - **Capture Assist** – `Capture-assist/capture_assist.py` waits five seconds, captures a screenshot, runs OCR, and
-  emits `ocr.text` events marked `assist`, appearing as **Assist-Capture** on the
+  emits `capture_assist.text` events marked `assist`, appearing as **Assist-Capture** on the
   overlay.
 - **Assist Commands** – `agent/plugins/assist_cmd_plugin.py` listens for
   keywords like capture, summarize, translate, repeat, or focus mode in STT

--- a/docs/ASSIST_COMMANDS.md
+++ b/docs/ASSIST_COMMANDS.md
@@ -3,8 +3,8 @@
 This document summarizes the assistive modules and the command plugin that react to speech in accessibility mode.
 
 ## MicTrans & Capture Assist
-- **MicTrans** (`Mic-trans-assist/mictrans.py`) captures microphone audio as voice input and posts `stt.text` events with `assist: true`. The overlay labels these transcripts as **Assist-MicTrans**.
-- **Capture Assist** (`Capture-assist/capture_assist.py`) waits five seconds, takes a screenshot, performs OCR, and emits `ocr.text` events marked with `assist: true`. The overlay displays the text as **Assist-Capture**.
+- **MicTrans** (`Mic-trans-assist/mictrans.py`) captures microphone audio as voice input and posts `mictrans.text` events with `assist: true`. The overlay labels these transcripts as **Assist-MicTrans**.
+- **Capture Assist** (`Capture-assist/capture_assist.py`) waits five seconds, takes a screenshot, performs OCR, and emits `capture_assist.text` events marked with `assist: true`. The overlay displays the text as **Assist-Capture**.
 
 ## Command Plugin
 `agent/plugins/assist_cmd_plugin.py` watches STT transcripts for the following Korean keywords and triggers the matching tools:

--- a/tests/test_assist.py
+++ b/tests/test_assist.py
@@ -102,7 +102,7 @@ def test_transcriber_posts_event():
     assert text == "hello"
     assert events == [
         (
-            "stt.text",
+            "mictrans.text",
             {"text": "hello", "source": "assist", "stt_model": "dummy", "assist": True},
             5,
         )
@@ -230,7 +230,7 @@ def test_llm_called_on_assist_command(monkeypatch):
     pcm = (np.full(cfg.sample_rate, 5000, dtype=np.int16)).tobytes()
     transcriber.transcribe(pcm)
     assert recorded["prompt"] == "tell me a joke"
-    assert events[0][0] == "stt.text"
+    assert events[0][0] == "mictrans.text"
     assert events[1][0] == "cmd.detected" and events[1][1]["cmd"] == "assist"
     assert events[2] == (
         "llm.chat",

--- a/tools/config/tools.yaml
+++ b/tools/config/tools.yaml
@@ -105,7 +105,7 @@ tools:
     module: tools.tool.assist_control
     class: null
     enabled: true
-    desc: "Assist microphone transcription"
+    desc: "Assist microphone transcription (emits mictrans.text)"
     input_schema:
       type: object
       properties: {}
@@ -123,7 +123,7 @@ tools:
     module: tools.tool.assist_control
     class: null
     enabled: true
-    desc: "Assist OCR capture"
+    desc: "Assist OCR capture (emits capture_assist.text)"
     input_schema:
       type: object
       properties: {}


### PR DESCRIPTION
## Summary
- standardize assist plugin events as `capture_assist.text` and `mictrans.text`
- translate these events and broadcast results through `translator.text` and overlay toasts
- document new event names and note unique tool prefixes in AGENTS.md

## Testing
- `pip install -r requirements.txt || true`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5603d65ac8333abfeca73c3ad04dd