### PR TITLE
forward plugin events to agent

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -70,3 +70,4 @@
 
 - Voice input and capture commands unified so MicTrans handles all voice input and Capture Assist performs screenshot OCR with a five-second delay in both modes; server, command router, tool gateway, and docs updated accordingly.
 - Capture Assist and MicTrans now emit `capture_assist.text` and `mictrans.text` events, translator plugin republishes translations via `translator.text` and overlay toasts. Tool list, docs, and AGENTS.md updated; broader assist integration still pending.
+- Overlay plugin endpoint now forwards plugin events to the agent server, removing the need for an Agent folder under Overlay.

--- a/Overlay/overlay_app.py
+++ b/Overlay/overlay_app.py
@@ -1637,9 +1637,30 @@ class OverlayWindow(QtWidgets.QWidget):
                 
                 # 이벤트 핸들러로 처리
                 success = handler.handle_event(event_type, payload)
-                
+
+                # Agent 서버에도 동일 이벤트 전달
+                try:
+                    agent = self.cfg.get("agent") or {}
+                    base = agent.get("event_url") or self.cfg.get("event_url")
+                    if base:
+                        base = base.rstrip("/").rsplit("/", 1)[0]
+                        url = f"{base}/plugin/event"
+                        import httpx
+                        httpx.post(
+                            url,
+                            json={
+                                "type": event_type,
+                                "payload": payload,
+                                "priority": priority,
+                                "source": source,
+                            },
+                            timeout=5.0,
+                        )
+                except Exception as e:
+                    logger.error(f"[proxy] forward to agent failed: {e}")
+
                 return {
-                    "ok": success, 
+                    "ok": success,
                     "message": "queued" if success else "failed",
                     "type": event_type
                 }


### PR DESCRIPTION
## Summary
- Forward `/plugin/event` requests from the overlay to the agent server so plugins reach agent `main.py`
- Log entry noting the forwarding to the agent server

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b620d265b08333930c9e7b3c85df8b