### PR TITLE
Ensure MicTrans posts mictrans.text for LLM trigger

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -71,3 +71,4 @@
 - Voice input and capture commands unified so MicTrans handles all voice input and Capture Assist performs screenshot OCR with a five-second delay in both modes; server, command router, tool gateway, and docs updated accordingly.
 - Capture Assist and MicTrans now emit `capture_assist.text` and `mictrans.text` events, translator plugin republishes translations via `translator.text` and overlay toasts. Tool list, docs, and AGENTS.md updated; broader assist integration still pending.
 - Overlay plugin endpoint now forwards plugin events to the agent server, removing the need for an Agent folder under Overlay.
+- MicTrans now emits mictrans.text events instead of stt.text so LLMs are triggered when using voice input; further wake-word and assist-mode integrations remain.

--- a/Mic-trans-assist/mictrans.py
+++ b/Mic-trans-assist/mictrans.py
@@ -295,7 +295,7 @@ class AssistTranscriber:
                 "stt_model": getattr(self.model, "model_size", "unknown"),
                 "assist": True,
             }
-            self.event_func("stt.text", payload)
+            self.event_func("mictrans.text", payload)
             if self.ui:
                 self.ui.push(text)
             cmd = detect_command(text, self.cfg)


### PR DESCRIPTION
## Summary
- Emit `mictrans.text` event instead of `stt.text` so voice input reaches the LLM pipeline
- Log note in Agent memory about the new MicTrans event

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: PortAudio library not found; ModuleNotFoundError: tools.tts_espeak)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6c019fdc8333a821efa1cd71c2fd