### PR TITLE
feat: toast capture assist OCR results

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -72,3 +72,4 @@
 - Capture Assist and MicTrans now emit `capture_assist.text` and `mictrans.text` events, translator plugin republishes translations via `translator.text` and overlay toasts. Tool list, docs, and AGENTS.md updated; broader assist integration still pending.
 - Overlay plugin endpoint now forwards plugin events to the agent server, removing the need for an Agent folder under Overlay.
 - MicTrans now emits mictrans.text events instead of stt.text so LLMs are triggered when using voice input; further wake-word and assist-mode integrations remain.
+- Capture Assist now overlays EasyOCR results prefixed with "[Capture-assist]" and shows a toast "EasyOCR로 OCR했어요. Overlay 확인 해주세요." when sending results; deeper assist integration remains.

--- a/Capture-assist/capture_assist.py
+++ b/Capture-assist/capture_assist.py
@@ -21,7 +21,12 @@ import numpy as np
 from PIL import Image
 from mss import mss
 import requests as _rq
-from tools.tts_espeak import speak
+# eSpeak TTS (optional)
+try:
+    from tools.tts_espeak import speak
+except Exception:  # pragma: no cover - optional dependency
+    def speak(*args, **kwargs):
+        return None
 
 # Backwards-compatibility alias for tests expecting module-level `requests`
 requests = _rq
@@ -206,7 +211,12 @@ def main() -> None:
     text = _run_ocr(img, cfg)
     text = _refine_with_jan(text)
     if text:
-        _post_event("capture_assist.text", {"text": text, "source": "easyocr_assist", "assist": True})
+        _post_event(
+            "capture_assist.text",
+            {"text": text, "source": "easyocr_assist", "assist": True},
+        )
+        _overlay_toast(f"[Capture-assist] {text}")
+        _notify("EasyOCR로 OCR했어요. Overlay 확인 해주세요.")
         print(text)
         if cfg.announce_text:
             speak(cfg.announce_text, lang="ko")

--- a/tests/test_capture_assist.py
+++ b/tests/test_capture_assist.py
@@ -90,3 +90,21 @@ def test_main_announces_delay_and_progress(monkeypatch):
     assert messages[0].startswith("5초")
     assert messages[1] == "이미지를 OCR 중입니다.."
     assert sleeps == [5]
+
+
+def test_main_overlay_and_toast_on_text(monkeypatch):
+    messages = []
+    overlays = []
+    monkeypatch.setattr(capture_assist, "_notify", lambda msg: messages.append(msg))
+    monkeypatch.setattr(
+        capture_assist, "_overlay_toast", lambda msg, title="Assist-Capture": overlays.append((title, msg))
+    )
+    monkeypatch.setattr(capture_assist, "_post_event", lambda t, p, _prio=5: None)
+    monkeypatch.setattr(capture_assist, "_capture_screen", lambda cfg: Image.new("RGB", (1, 1)))
+    monkeypatch.setattr(capture_assist, "_run_ocr", lambda img, cfg: "hello")
+    monkeypatch.setattr(capture_assist.time, "sleep", lambda s: None)
+    monkeypatch.setattr(sys, "argv", ["capture_assist.py"])
+    monkeypatch.setattr(capture_assist, "speak", lambda text, lang="ko": None)
+    capture_assist.main()
+    assert ("Assist-Capture", "[Capture-assist] hello") in overlays
+    assert messages[-1] == "EasyOCR로 OCR했어요. Overlay 확인 해주세요."


### PR DESCRIPTION
## Summary
- Display EasyOCR capture results on the overlay with a `[Capture-assist]` prefix
- Notify users with a toast message when EasyOCR OCR completes
- Cover overlay and toast workflow with tests and optional TTS import fallback

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement torch>=2.1.0)*
- `pytest -q` *(fails: PortAudio library not found)*
- `pytest tests/test_capture_assist.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bbbdea9400833385093ee54adfc400