### PR TITLE
feat: clean capture assist logs after overlay

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -73,3 +73,4 @@
 - Overlay plugin endpoint now forwards plugin events to the agent server, removing the need for an Agent folder under Overlay.
 - MicTrans now emits mictrans.text events instead of stt.text so LLMs are triggered when using voice input; further wake-word and assist-mode integrations remain.
 - Capture Assist now overlays EasyOCR results prefixed with "[Capture-assist]" and shows a toast "EasyOCR로 OCR했어요. Overlay 확인 해주세요." when sending results; deeper assist integration remains.
+- Capture Assist now removes its log file after posting overlay output so logs stay clean; further capture assist features remain.

--- a/Capture-assist/capture_assist.py
+++ b/Capture-assist/capture_assist.py
@@ -45,6 +45,8 @@ _EVENT_URL = (
 )
 _EVENT_KEY = os.environ.get("EVENT_KEY") or os.environ.get("AGENT_EVENT_KEY")
 
+LOG_PATH = pathlib.Path(__file__).with_name("capture_assist.log")
+
 
 def _post_event(_type: str, _payload: dict, _prio: int = 5) -> None:
     try:
@@ -124,6 +126,16 @@ def _refine_with_jan(text: str) -> str:
         return (data["choices"][0]["message"]["content"] or "").strip() or text
     except Exception:
         return text
+
+
+def _clear_log(path: pathlib.Path | None = None) -> None:
+    """Remove the capture assist log file if it exists."""
+    log = path or LOG_PATH
+    try:
+        if log.exists():
+            log.unlink()
+    except Exception:
+        pass
 
 
 @dataclass
@@ -220,7 +232,7 @@ def main() -> None:
         print(text)
         if cfg.announce_text:
             speak(cfg.announce_text, lang="ko")
-
+    _clear_log()
 
 if __name__ == "__main__":  # pragma: no cover - manual execution
     main()

--- a/tests/test_capture_assist.py
+++ b/tests/test_capture_assist.py
@@ -108,3 +108,19 @@ def test_main_overlay_and_toast_on_text(monkeypatch):
     capture_assist.main()
     assert ("Assist-Capture", "[Capture-assist] hello") in overlays
     assert messages[-1] == "EasyOCR로 OCR했어요. Overlay 확인 해주세요."
+
+
+def test_main_cleans_log(monkeypatch, tmp_path):
+    log_file = tmp_path / "capture_assist.log"
+    log_file.write_text("old", encoding="utf-8")
+    monkeypatch.setattr(capture_assist, "LOG_PATH", log_file)
+    monkeypatch.setattr(capture_assist, "_notify", lambda msg: None)
+    monkeypatch.setattr(capture_assist, "_overlay_toast", lambda msg, title="Assist-Capture": None)
+    monkeypatch.setattr(capture_assist, "_post_event", lambda t, p, _prio=5: None)
+    monkeypatch.setattr(capture_assist, "_capture_screen", lambda cfg: Image.new("RGB", (1, 1)))
+    monkeypatch.setattr(capture_assist, "_run_ocr", lambda img, cfg: "hello")
+    monkeypatch.setattr(capture_assist.time, "sleep", lambda s: None)
+    monkeypatch.setattr(sys, "argv", ["capture_assist.py"])
+    monkeypatch.setattr(capture_assist, "speak", lambda text, lang="ko": None)
+    capture_assist.main()
+    assert not log_file.exists()


### PR DESCRIPTION
## Summary
- clean up capture assist logs after posting overlay output
- test that capture assist log file is removed

## Testing
- `pip install -r requirements.txt || true`
- `pytest -q` *(fails: PortAudio library not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc03e9b9083338ad36758b1818ba7