### PR TITLE
Refactor capture assist log lifecycle and server cleanup

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -73,4 +73,4 @@
 - Overlay plugin endpoint now forwards plugin events to the agent server, removing the need for an Agent folder under Overlay.
 - MicTrans now emits mictrans.text events instead of stt.text so LLMs are triggered when using voice input; further wake-word and assist-mode integrations remain.
 - Capture Assist now overlays EasyOCR results prefixed with "[Capture-assist]" and shows a toast "EasyOCR로 OCR했어요. Overlay 확인 해주세요." when sending results; deeper assist integration remains.
-- Capture Assist now removes its log file after posting overlay output so logs stay clean; further capture assist features remain.
+- Capture Assist logs now record each OCR result; the agent server prunes entries older than one minute and clears the log on shutdown. Further capture assist logging features remain.

--- a/Capture-assist/capture_assist.py
+++ b/Capture-assist/capture_assist.py
@@ -138,6 +138,16 @@ def _clear_log(path: pathlib.Path | None = None) -> None:
         pass
 
 
+def _append_log(text: str, path: pathlib.Path | None = None) -> None:
+    """Append a timestamped entry to the capture assist log."""
+    log = path or LOG_PATH
+    try:
+        with open(log, "a", encoding="utf-8") as f:
+            f.write(f"{time.time()}\t{text}\n")
+    except Exception:
+        pass
+
+
 @dataclass
 class OCRAssistConfig:
     """Configuration for assistive OCR capture."""
@@ -229,10 +239,10 @@ def main() -> None:
         )
         _overlay_toast(f"[Capture-assist] {text}")
         _notify("EasyOCR로 OCR했어요. Overlay 확인 해주세요.")
+        _append_log(text)
         print(text)
         if cfg.announce_text:
             speak(cfg.announce_text, lang="ko")
-    _clear_log()
 
 if __name__ == "__main__":  # pragma: no cover - manual execution
     main()

--- a/agent/server.py
+++ b/agent/server.py
@@ -1,10 +1,46 @@
 import asyncio, os, sys, subprocess, platform, time
 from contextlib import asynccontextmanager
+from pathlib import Path
 from fastapi import FastAPI, HTTPException, Depends, Header, APIRouter
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from loguru import logger
 from .schemas import Event, Result, PluginEventIn
+
+CAPTURE_LOG_PATH = Path(__file__).resolve().parents[1] / "Capture-assist" / "capture_assist.log"
+
+
+def _clear_capture_log(path: Path = CAPTURE_LOG_PATH) -> None:
+    try:
+        if path.exists():
+            path.unlink()
+    except Exception:
+        pass
+
+
+def _prune_capture_log(path: Path = CAPTURE_LOG_PATH, older_than: float = 60.0) -> None:
+    now = time.time()
+    try:
+        if not path.exists():
+            return
+        lines = path.read_text(encoding="utf-8").splitlines()
+        kept = []
+        for line in lines:
+            try:
+                ts, _rest = line.split("\t", 1)
+                if float(ts) >= now - older_than:
+                    kept.append(line)
+            except Exception:
+                continue
+        path.write_text("\n".join(kept) + ("\n" if kept else ""), encoding="utf-8")
+    except Exception:
+        pass
+
+
+async def _capture_log_worker():
+    while True:
+        await asyncio.sleep(60)
+        _prune_capture_log()
 
 def _spawn_overlay(cfg):
     ov = (cfg or {}).get("overlay", {}) or {}
@@ -86,6 +122,7 @@ def create_app(ctx, plugins=None):
         app.state.capture_proc = None
         app.state.assist_mode = bool(getattr(ctx, "assist_mode", False))
         app.state.assist_task = None
+        app.state.capture_log_task = asyncio.create_task(_capture_log_worker())
         # Watch overlay process so the agent exits when overlay closes
         if app.state.overlay_proc:
             async def _overlay_watch():
@@ -351,6 +388,21 @@ def create_app(ctx, plugins=None):
             except Exception as e:
                 logger.debug(f"[lifespan] assist task cancel error: {e}")
             app.state.assist_task = None
+
+            # Stop capture log cleaner
+            try:
+                task = getattr(app.state, "capture_log_task", None)
+                if task:
+                    task.cancel()
+                    try:
+                        await task
+                    except Exception:
+                        pass
+            except Exception as e:
+                logger.debug(f"[lifespan] capture log task cancel error: {e}")
+            app.state.capture_log_task = None
+
+            _clear_capture_log()
 
     app = FastAPI(title="Luna Local Agent", lifespan=lifespan)
 

--- a/tests/test_capture_assist.py
+++ b/tests/test_capture_assist.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from PIL import Image
 import numpy as np
 import sys
+import time
 
 spec = importlib.util.spec_from_file_location(
     "capture_assist", Path(__file__).resolve().parents[1] / "Capture-assist" / "capture_assist.py"
@@ -110,9 +111,8 @@ def test_main_overlay_and_toast_on_text(monkeypatch):
     assert messages[-1] == "EasyOCR로 OCR했어요. Overlay 확인 해주세요."
 
 
-def test_main_cleans_log(monkeypatch, tmp_path):
+def test_main_appends_log(monkeypatch, tmp_path):
     log_file = tmp_path / "capture_assist.log"
-    log_file.write_text("old", encoding="utf-8")
     monkeypatch.setattr(capture_assist, "LOG_PATH", log_file)
     monkeypatch.setattr(capture_assist, "_notify", lambda msg: None)
     monkeypatch.setattr(capture_assist, "_overlay_toast", lambda msg, title="Assist-Capture": None)
@@ -123,4 +123,16 @@ def test_main_cleans_log(monkeypatch, tmp_path):
     monkeypatch.setattr(sys, "argv", ["capture_assist.py"])
     monkeypatch.setattr(capture_assist, "speak", lambda text, lang="ko": None)
     capture_assist.main()
-    assert not log_file.exists()
+    assert log_file.exists()
+    assert "hello" in log_file.read_text(encoding="utf-8")
+
+
+def test_prune_log_removes_old_entries(tmp_path):
+    from agent import server
+    log_file = tmp_path / "capture_assist.log"
+    now = time.time()
+    lines = [f"{now-120}\told", f"{now-30}\tnew"]
+    log_file.write_text("\n".join(lines), encoding="utf-8")
+    server._prune_capture_log(log_file, older_than=60)
+    remaining = log_file.read_text(encoding="utf-8").strip().splitlines()
+    assert remaining == [lines[1]]


### PR DESCRIPTION
## Summary
- Log capture assist OCR results to a persistent file
- Prune capture logs older than one minute via server background task
- Clear capture assist log when the server shuts down
- Add tests covering log persistence and pruning

## Testing
- `pip install -r requirements.txt` *(fails: Could not find torch>=2.1.0)*
- `pytest -q` *(fails: PortAudio library not found)*
- `pytest tests/test_capture_assist.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bbc1aaeaac8333b5297a4c0f6b1738