### PR TITLE
Display capture assist OCR results in overlay

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -74,3 +74,4 @@
 - MicTrans now emits mictrans.text events instead of stt.text so LLMs are triggered when using voice input; further wake-word and assist-mode integrations remain.
 - Capture Assist now overlays EasyOCR results prefixed with "[Capture-assist]" and shows a toast "EasyOCR로 OCR했어요. Overlay 확인 해주세요." when sending results; deeper assist integration remains.
 - Capture Assist logs now record each OCR result; the agent server prunes entries older than one minute and clears the log on shutdown. Further capture assist logging features remain.
+- Overlay now labels capture_assist.text events as "Assist-Capture" so OCR results appear in the overlay window; further integration like ROI highlighting remains.

--- a/Overlay/overlay_app_enhanced.py
+++ b/Overlay/overlay_app_enhanced.py
@@ -111,7 +111,7 @@ class EnhancedEventHandler:
             if event_type.startswith("stt.") or event_type.startswith("mictrans."):
                 success = self._handle_stt(payload)
             elif event_type.startswith("ocr.") or event_type.startswith("capture_assist."):
-                success = self._handle_ocr(payload)
+                success = self._handle_ocr(event_type, payload)
             elif event_type.startswith("web.search"):
                 success = self._handle_web_search(payload)
             elif event_type.startswith("llm.") or event_type.startswith("lm."):
@@ -199,24 +199,25 @@ class EnhancedEventHandler:
         self._emit_safe("🎤 STT", display_text)
         return True
     
-    def _handle_ocr(self, payload: Dict[str, Any]) -> bool:
+    def _handle_ocr(self, event_type: str, payload: Dict[str, Any]) -> bool:
         """OCR 이벤트 처리"""
         text = payload.get("text", "") or payload.get("ocr", "")
         if not text:
             return False
-            
+
         text = text.strip()
         display_text = text
-        
+
         bbox = payload.get("bbox", [])
         if bbox and len(bbox) >= 2:
             display_text += f" @({bbox[0]:.0f},{bbox[1]:.0f})"
-        
+
         confidence = payload.get("confidence", 0)
         if confidence > 0:
             display_text += f" ({confidence:.0%})"
-            
-        self._emit_safe("👁️ OCR", display_text)
+
+        label = "Assist-Capture" if event_type.startswith("capture_assist.") or payload.get("assist") else "👁️ OCR"
+        self._emit_safe(label, display_text)
         return True
     
     def _handle_web_search(self, payload: Dict[str, Any]) -> bool:


### PR DESCRIPTION
## Summary
- Forward capture_assist events through OCR handler
- Label capture assistant OCR output as "Assist-Capture" so text shows in overlay
- Record overlay update in working memory

## Testing
- `pip install -r requirements.txt` *(failed: Could not find a version that satisfies the requirement fastapi>=0.111.1)*
- `pytest -q` *(failed: ModuleNotFoundError: No module named 'sounddevice')*

------
https://chatgpt.com/codex/tasks/task_e_68bbc368aa34833382c3e685331e74d2