### PR TITLE
fix: prevent capture assist event dedup

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -75,3 +75,4 @@
 - Capture Assist now overlays EasyOCR results prefixed with "[Capture-assist]" and shows a toast "EasyOCR로 OCR했어요. Overlay 확인 해주세요." when sending results; deeper assist integration remains.
 - Capture Assist logs now record each OCR result; the agent server prunes entries older than one minute and clears the log on shutdown. Further capture assist logging features remain.
 - Overlay now labels capture_assist.text events as "Assist-Capture" so OCR results appear in the overlay window; further integration like ROI highlighting remains.
+- Capture Assist plugin no longer republishes events after cleaning text, preventing dedup drops; similar cleanup for MicTrans and broader assist integration still pending.

--- a/agent/plugins/capture_assist_plugin.py
+++ b/agent/plugins/capture_assist_plugin.py
@@ -12,5 +12,4 @@ class CaptureAssistPlugin(BasePlugin):
         text = event.payload.get("text", "")
         text = text.replace("\u200b", "").strip()
         event.payload["text"] = text
-        await self.ctx.bus.publish(event)
-        logger.debug(f"[{self.name}] cleaned and republished capture_assist.text")
+        logger.debug(f"[{self.name}] cleaned capture_assist.text")


### PR DESCRIPTION
## Summary
- avoid deduping capture assist events by stopping unnecessary republishes
- log work in memory file

## Testing
- `pip install -r requirements.txt` (failed: Could not find a version that satisfies the requirement torch>=2.1.0)
- `pytest -q` (failed: PortAudio library not found)


------
https://chatgpt.com/codex/tasks/task_e_68bbc6681c088333bf8572d1de4ed67b