### PR TITLE
Forward assist OCR/STT events to overlay

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -76,3 +76,5 @@
 - Capture Assist logs now record each OCR result; the agent server prunes entries older than one minute and clears the log on shutdown. Further capture assist logging features remain.
 - Overlay now labels capture_assist.text events as "Assist-Capture" so OCR results appear in the overlay window; further integration like ROI highlighting remains.
 - Capture Assist plugin no longer republishes events after cleaning text, preventing dedup drops; similar cleanup for MicTrans and broader assist integration still pending.
+
+- Overlay sink now forwards capture_assist and mictrans events so OCR and voice input results appear in the overlay; further assist integration remains.

--- a/agent/plugins/overlay_sink.py
+++ b/agent/plugins/overlay_sink.py
@@ -30,7 +30,16 @@ TIMEOUT_SECONDS = float(os.environ.get("OVERLAY_TIMEOUT", "3.0"))
 
 class EnhancedOverlaySink(BasePlugin):
     name = "enhanced_overlay_sink"
-    handles: List[str] = ["stt.", "ocr.", "llm.", "lm.", "web.search", "overlay."]
+    handles: List[str] = [
+        "stt.",
+        "mictrans.",
+        "ocr.",
+        "capture_assist.",
+        "llm.",
+        "lm.",
+        "web.search",
+        "overlay.",
+    ]
 
     def __init__(self):
         self.last_connection_check = 0
@@ -251,9 +260,9 @@ class EnhancedOverlaySink(BasePlugin):
             # 이벤트 타입별 포맷팅
             formatted_event = None
             
-            if event_type.startswith("stt."):
+            if event_type.startswith("stt.") or event_type.startswith("mictrans."):
                 formatted_event = self._format_stt_event(payload)
-            elif event_type.startswith("ocr."):
+            elif event_type.startswith("ocr.") or event_type.startswith("capture_assist."):
                 formatted_event = self._format_ocr_event(payload)
             elif event_type.startswith("llm.") or event_type.startswith("lm."):
                 formatted_event = self._format_llm_event(payload)

--- a/tests/test_overlay_sink.py
+++ b/tests/test_overlay_sink.py
@@ -1,0 +1,41 @@
+import asyncio
+from agent.plugins.overlay_sink import EnhancedOverlaySink
+from agent.schemas import Event
+
+
+def test_capture_assist_event_forwarded(monkeypatch):
+    sink = EnhancedOverlaySink()
+    captured = {}
+
+    async def fake_post(url, payload):
+        captured['url'] = url
+        captured['payload'] = payload
+        return True
+
+    sink._post_with_retry = fake_post  # type: ignore
+    event = Event(type="capture_assist.text", payload={"text": "hello", "assist": True})
+    asyncio.run(sink.handle(event))
+
+    assert captured['payload']['type'] == 'ocr.result'
+    inner = captured['payload']['payload']
+    assert inner['text'] == 'hello'
+    assert inner['assist'] is True
+
+
+def test_mictrans_event_forwarded(monkeypatch):
+    sink = EnhancedOverlaySink()
+    captured = {}
+
+    async def fake_post(url, payload):
+        captured['payload'] = payload
+        return True
+
+    sink._post_with_retry = fake_post  # type: ignore
+    event = Event(type="mictrans.text", payload={"text": "hi", "translation": "안녕"})
+    asyncio.run(sink.handle(event))
+
+    assert captured['payload']['type'] == 'stt.result'
+    inner = captured['payload']['payload']
+    assert inner['original'] == 'hi'
+    assert inner['translation'] == '안녕'
+    assert '안녕' in inner['text']


### PR DESCRIPTION
## Summary
- Extend overlay sink to handle `capture_assist.*` and `mictrans.*` events, forwarding OCR and voice input results to the overlay
- Add tests for overlay sink formatting of capture assist and mictrans events
- Record overlay sink enhancement in working memory

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement torch>=2.1.0)*
- `pytest -q` *(fails: OSError: PortAudio library not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbcafa55988333bc113e4d855f3bd1