### PR TITLE
Allow concurrent STT and MicTrans alongside OCR tools

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -78,3 +78,6 @@
 - Capture Assist plugin no longer republishes events after cleaning text, preventing dedup drops; similar cleanup for MicTrans and broader assist integration still pending.
 
 - Overlay sink now forwards capture_assist and mictrans events so OCR and voice input results appear in the overlay; further assist integration remains.
+- Tool gateway now routes stt_start/stt_stop to stt.* and ocr_start/ocr_stop to ocr.*, with server spawning separate STT and MicTrans processes so basic STT/OCR can run alongside MicTrans and Capture Assist. Further resource coordination and wake-word integration remain.
+- Server logs overlay.toast events to avoid missing subscriber warnings; test ensures toast logs.
+- Tool call schema switched to snake_case with clear STT/OCR vs MicTrans/Capture Assist descriptions so local LLMs don't confuse subtitle translation with voice input or EasyOCR capture; prompts, tool configs, and docs updated accordingly.

--- a/agent/server.py
+++ b/agent/server.py
@@ -118,6 +118,7 @@ def create_app(ctx, plugins=None):
         # Startup
         app.state.overlay_proc = _spawn_overlay(getattr(ctx, "config", {}))
         app.state.stt_proc = None
+        app.state.mictrans_proc = None
         app.state.ocr_proc = None
         app.state.capture_proc = None
         app.state.assist_mode = bool(getattr(ctx, "assist_mode", False))
@@ -151,35 +152,38 @@ def create_app(ctx, plugins=None):
                     app.state._plugin_unsubs.append((prefix, _handler))
                     logger.info(f"[plugin] subscribed '{getattr(p,'name',p)}' to '{prefix}'")
 
+            async def _toast_handler(ev):
+                payload = ev.payload or {}
+                title = payload.get("title", "")
+                text = payload.get("text", "")
+                logger.info(f"[toast] {title}: {text}")
+
+            ctx.bus.subscribe("overlay.toast", _toast_handler)
+            app.state._plugin_unsubs.append(("overlay.toast", _toast_handler))
+
             async def _stt_handler(ev):
                 if ev.type == "stt.start":
-                    # mictrans가 실행 중이면 종료하고 STT 시작
                     if app.state.stt_proc and app.state.stt_proc.poll() is None:
-                        logger.info("[stt] terminating mictrans to start STT")
-                        await _terminate_proc(app.state.stt_proc, name="mictrans", timeout=3.0)
-                    
-                    # 기본 STT (영어 뉴스용) 시작
-                    app.state.stt_proc = _spawn_tool(getattr(ctx, "config", {}), "stt.start")
-                    logger.info("[stt] started basic STT (VSRG-Ts-to-kr.py)")
-                    
-                elif ev.type == "mictrans.start":
-                    # STT가 실행 중이면 종료하고 mictrans 시작
-                    if app.state.stt_proc and app.state.stt_proc.poll() is None:
-                        logger.info("[mictrans] terminating STT to start mictrans")
-                        await _terminate_proc(app.state.stt_proc, name="stt", timeout=3.0)
-                    
-                    # 보조모드 음성입력 (Whisper) 시작
-                    app.state.stt_proc = _spawn_tool(getattr(ctx, "config", {}), "mictrans.start")
-                    logger.info("[mictrans] started voice input (Whisper)")
-                    
+                        logger.info("[stt] already running")
+                    else:
+                        app.state.stt_proc = _spawn_tool(getattr(ctx, "config", {}), "stt.start")
+                        logger.info("[stt] started basic STT (VSRG-Ts-to-kr.py)")
+
                 elif ev.type == "stt.stop":
                     await _terminate_proc(getattr(app.state, "stt_proc", None), name="stt", timeout=3.0)
                     app.state.stt_proc = None
                     logger.info("[stt] stopped")
-                    
+
+                elif ev.type == "mictrans.start":
+                    if app.state.mictrans_proc and app.state.mictrans_proc.poll() is None:
+                        logger.info("[mictrans] already running")
+                    else:
+                        app.state.mictrans_proc = _spawn_tool(getattr(ctx, "config", {}), "mictrans.start")
+                        logger.info("[mictrans] started voice input (Whisper)")
+
                 elif ev.type == "mictrans.stop":
-                    await _terminate_proc(getattr(app.state, "stt_proc", None), name="mictrans", timeout=3.0)
-                    app.state.stt_proc = None
+                    await _terminate_proc(getattr(app.state, "mictrans_proc", None), name="mictrans", timeout=3.0)
+                    app.state.mictrans_proc = None
                     logger.info("[mictrans] stopped")
 
             ctx.bus.subscribe("stt.", _stt_handler)
@@ -223,9 +227,13 @@ def create_app(ctx, plugins=None):
                     ctx.assist_mode = True
                     # 기존 프로세스 정리만 하고 자동 시작하지 않음
                     await _terminate_proc(getattr(app.state, "stt_proc", None), name="stt", timeout=3.0)
+                    await _terminate_proc(getattr(app.state, "mictrans_proc", None), name="mictrans", timeout=3.0)
                     await _terminate_proc(getattr(app.state, "ocr_proc", None), name="ocr", timeout=3.0)
+                    await _terminate_proc(getattr(app.state, "capture_proc", None), name="capture_assist", timeout=3.0)
                     app.state.stt_proc = None
+                    app.state.mictrans_proc = None
                     app.state.ocr_proc = None
+                    app.state.capture_proc = None
 
                     # 보조모드 활성화됨 - 수동으로 도구 시작 필요
                     logger.info("[assist] 보조모드 활성화 - 명시적 명령으로 도구 시작 필요")
@@ -241,9 +249,13 @@ def create_app(ctx, plugins=None):
                             pass
                     app.state.assist_task = None
                     await _terminate_proc(getattr(app.state, "stt_proc", None), name="stt", timeout=3.0)
+                    await _terminate_proc(getattr(app.state, "mictrans_proc", None), name="mictrans", timeout=3.0)
                     await _terminate_proc(getattr(app.state, "ocr_proc", None), name="ocr", timeout=3.0)
+                    await _terminate_proc(getattr(app.state, "capture_proc", None), name="capture_assist", timeout=3.0)
                     app.state.stt_proc = None
+                    app.state.mictrans_proc = None
                     app.state.ocr_proc = None
+                    app.state.capture_proc = None
                     logger.info("[assist] 보조모드 종료 - 수동으로 도구 시작 필요")
 
             ctx.bus.subscribe("assist.", _assist_handler)
@@ -360,12 +372,14 @@ def create_app(ctx, plugins=None):
                 logger.debug(f"[lifespan] overlay terminate error: {e}")
             app.state.overlay_proc = None
 
-            # Shutdown STT
+            # Shutdown STT and MicTrans
             try:
                 await _terminate_proc(getattr(app.state, "stt_proc", None), name="stt", timeout=3.0)
+                await _terminate_proc(getattr(app.state, "mictrans_proc", None), name="mictrans", timeout=3.0)
             except Exception as e:
                 logger.debug(f"[lifespan] stt terminate error: {e}")
             app.state.stt_proc = None
+            app.state.mictrans_proc = None
 
             # Shutdown OCR
             try:

--- a/agent/tool_gateway.py
+++ b/agent/tool_gateway.py
@@ -45,10 +45,10 @@ TOOL_ROUTES = {
         ("mictrans.stop", {"reason": "tool"}),
         ("capture_assist.stop", {"reason": "tool"}),
     ],
-    "stt_start": lambda args, ctx: [("mictrans.start", {"reason": "tool"})],
-    "stt_stop": lambda args, ctx: [("mictrans.stop", {"reason": "tool"})],
-    "ocr_start": lambda args, ctx: [("capture_assist.start", {"reason": "tool"})],
-    "ocr_stop": lambda args, ctx: [("capture_assist.stop", {"reason": "tool"})],
+    "stt_start": lambda args, ctx: [("stt.start", {"reason": "tool"})],
+    "stt_stop": lambda args, ctx: [("stt.stop", {"reason": "tool"})],
+    "ocr_start": lambda args, ctx: [("ocr.start", {"reason": "tool"})],
+    "ocr_stop": lambda args, ctx: [("ocr.stop", {"reason": "tool"})],
 }
 
 

--- a/docs/ASSIST_COMMANDS.md
+++ b/docs/ASSIST_COMMANDS.md
@@ -2,9 +2,13 @@
 
 This document summarizes the assistive modules and the command plugin that react to speech in accessibility mode.
 
-## MicTrans & Capture Assist
+## STT & OCR vs. Assist Tools
+- **STT** (`STT/assist.py` etc.) translates audio subtitles from English to Korean using the default STT pipeline.
+- **OCR** (`OCR/main.py` etc.) uses a vision model to extract and translate text from the screen.
+
+### Assist Tools
 - **MicTrans** (`Mic-trans-assist/mictrans.py`) captures microphone audio as voice input and posts `mictrans.text` events with `assist: true`. The overlay labels these transcripts as **Assist-MicTrans**.
-- **Capture Assist** (`Capture-assist/capture_assist.py`) waits five seconds, takes a screenshot, performs OCR, and emits `capture_assist.text` events marked with `assist: true`. The overlay displays the text as **Assist-Capture**.
+- **Capture Assist** (`Capture-assist/capture_assist.py`) waits five seconds, takes a screenshot, performs EasyOCR, and emits `capture_assist.text` events marked with `assist: true`. The overlay displays the text as **Assist-Capture**.
 
 ## Command Plugin
 `agent/plugins/assist_cmd_plugin.py` watches STT transcripts for the following Korean keywords and triggers the matching tools:

--- a/prompts/tool_system_qwen.txt
+++ b/prompts/tool_system_qwen.txt
@@ -5,6 +5,11 @@
 "보조"나 "어시스트"가 포함되지 않으면 보조용 툴을 호출하지 말라.
 "캡쳐해줘" 요청은 항상 ocr_capture를 사용하라.
 
+STT는 영상/음성의 영→한 자막 번역용 기본 STT 모듈이다.
+MicTrans는 사용자의 음성 명령 입력을 위한 보조 마이크 전사 도구다.
+OCR은 비전(VL) 모델 기반 OCR 번역을 수행한다.
+Capture Assist(ocr_capture/capture_assist_*)는 EasyOCR을 사용한 캡쳐 도구다.
+
 예시:
 <|user|>캡쳐해줘
 <|assistant|>{"tool_calls":[{"type":"function","function":{"name":"ocr_capture","arguments":"{}"}}]}

--- a/schemas/tool_calls.json
+++ b/schemas/tool_calls.json
@@ -1,17 +1,17 @@
 [
-  { "type": "function", "function": { "name": "mictrans.start", "description": "Start mic-transcription assist", "parameters": { "type": "object", "properties": {}, "additionalProperties": false } } },
-  { "type": "function", "function": { "name": "mictrans.stop",  "description": "Stop mic-transcription assist",  "parameters": { "type": "object", "properties": {}, "additionalProperties": false } } },
+  {"type": "function", "function": {"name": "mictrans_start", "description": "Start MicTrans voice input (emits mictrans.text)", "parameters": {"type": "object", "properties": {}, "additionalProperties": false}}},
+  {"type": "function", "function": {"name": "mictrans_stop",  "description": "Stop MicTrans voice input",          "parameters": {"type": "object", "properties": {}, "additionalProperties": false}}},
 
-  { "type": "function", "function": { "name": "stt.start",      "description": "Start STT (normal mode)",        "parameters": { "type": "object", "properties": {}, "additionalProperties": false } } },
-  { "type": "function", "function": { "name": "stt.stop",       "description": "Stop STT",                       "parameters": { "type": "object", "properties": {}, "additionalProperties": false } } },
+  {"type": "function", "function": {"name": "stt_start",       "description": "Start STT translator (English→Korean subtitles)", "parameters": {"type": "object", "properties": {}, "additionalProperties": false}}},
+  {"type": "function", "function": {"name": "stt_stop",        "description": "Stop STT translator",                   "parameters": {"type": "object", "properties": {}, "additionalProperties": false}}},
 
-  { "type": "function", "function": { "name": "ocr.start",      "description": "Start OCR (VLM+translate)",      "parameters": { "type": "object", "properties": {}, "additionalProperties": false } } },
-  { "type": "function", "function": { "name": "ocr.stop",       "description": "Stop OCR",                      "parameters": { "type": "object", "properties": {}, "additionalProperties": false } } },
+  {"type": "function", "function": {"name": "ocr_start",       "description": "Start OCR using vision model",           "parameters": {"type": "object", "properties": {}, "additionalProperties": false}}},
+  {"type": "function", "function": {"name": "ocr_stop",        "description": "Stop OCR",                               "parameters": {"type": "object", "properties": {}, "additionalProperties": false}}},
 
-  { "type": "function", "function": { "name": "capture_assist.start", "description": "Start Capture Assist (EasyOCR)", "parameters": { "type": "object", "properties": {}, "additionalProperties": false } } },
-  { "type": "function", "function": { "name": "capture_assist.stop",  "description": "Stop Capture Assist",         "parameters": { "type": "object", "properties": {}, "additionalProperties": false } } },
+  {"type": "function", "function": {"name": "ocr_capture",     "description": "Capture screen with EasyOCR (Capture Assist)", "parameters": {"type": "object", "properties": {"region": {"type": "string"}}, "additionalProperties": false}}},
+  {"type": "function", "function": {"name": "capture_assist_start", "description": "Start Capture Assist (EasyOCR)",         "parameters": {"type": "object", "properties": {}, "additionalProperties": false}}},
+  {"type": "function", "function": {"name": "capture_assist_stop",  "description": "Stop Capture Assist",                     "parameters": {"type": "object", "properties": {}, "additionalProperties": false}}},
 
-  { "type": "function", "function": { "name": "assist.on",      "description": "Enable assist mode",            "parameters": { "type": "object", "properties": {}, "additionalProperties": false } } },
-  { "type": "function", "function": { "name": "assist.off",     "description": "Disable assist mode",           "parameters": { "type": "object", "properties": {}, "additionalProperties": false } } }
+  {"type": "function", "function": {"name": "assist_on",       "description": "Enable assist mode",                      "parameters": {"type": "object", "properties": {}, "additionalProperties": false}}},
+  {"type": "function", "function": {"name": "assist_off",      "description": "Disable assist mode",                     "parameters": {"type": "object", "properties": {}, "additionalProperties": false}}}
 ]
-

--- a/tests/test_overlay_toast.py
+++ b/tests/test_overlay_toast.py
@@ -1,0 +1,32 @@
+import asyncio
+from types import SimpleNamespace
+from loguru import logger
+
+from agent.event_bus import EventBus
+from agent.server import create_app
+from agent.schemas import Event
+
+
+async def dispatch_all(bus: EventBus):
+    while not bus.queue.empty():
+        _, _, e = await bus.queue.get()
+        for prefix, handlers in bus.subscribers.items():
+            if e.type.startswith(prefix):
+                for h in handlers:
+                    await h(e)
+
+
+def test_overlay_toast_logged():
+    ctx = SimpleNamespace(config={}, bus=EventBus(dedup_window=0), assist_mode=False)
+    app = create_app(ctx, plugins=[])
+    messages = []
+    token = logger.add(lambda m: messages.append(m), level="INFO")
+    try:
+        async def _run():
+            async with app.router.lifespan_context(app):
+                await ctx.bus.publish(Event(type="overlay.toast", payload={"title": "hi", "text": "there"}))
+                await dispatch_all(ctx.bus)
+        asyncio.run(_run())
+    finally:
+        logger.remove(token)
+    assert any("[toast]" in str(m) for m in messages)

--- a/tests/test_tool_gateway.py
+++ b/tests/test_tool_gateway.py
@@ -46,10 +46,10 @@ def test_tool_gateway_basic_stt_ocr():
     ]
     asyncio.run(handle_tool_calls(tool_calls, ctx, bus))
     assert [e.type for e in bus.events] == [
-        "mictrans.start",
-        "capture_assist.start",
-        "mictrans.stop",
-        "capture_assist.stop",
+        "stt.start",
+        "ocr.start",
+        "stt.stop",
+        "ocr.stop",
     ]
 
 
@@ -88,8 +88,8 @@ def test_stt_ocr_start_assist_mode():
     ]
     asyncio.run(handle_tool_calls(tool_calls, ctx, bus))
     assert [e.type for e in bus.events] == [
-        "mictrans.start",
-        "capture_assist.start",
+        "stt.start",
+        "ocr.start",
     ]
 
 

--- a/tools/config/tools.yaml
+++ b/tools/config/tools.yaml
@@ -69,7 +69,7 @@ tools:
     module: tools.tool.assist_control
     class: null
     enabled: true
-    desc: "Start STT"
+    desc: "Start STT translator (English→Korean subtitles)"
     input_schema:
       type: object
       properties: {}
@@ -78,7 +78,7 @@ tools:
     module: tools.tool.assist_control
     class: null
     enabled: true
-    desc: "Stop STT"
+    desc: "Stop STT translator"
     input_schema:
       type: object
       properties: {}
@@ -87,7 +87,7 @@ tools:
     module: tools.tool.assist_control
     class: null
     enabled: true
-    desc: "Start OCR"
+    desc: "Start OCR using vision model"
     input_schema:
       type: object
       properties: {}
@@ -105,7 +105,7 @@ tools:
     module: tools.tool.assist_control
     class: null
     enabled: true
-    desc: "Assist microphone transcription (emits mictrans.text)"
+    desc: "Assist microphone transcription for voice input (emits mictrans.text)"
     input_schema:
       type: object
       properties: {}
@@ -123,7 +123,7 @@ tools:
     module: tools.tool.assist_control
     class: null
     enabled: true
-    desc: "Assist OCR capture (emits capture_assist.text)"
+    desc: "Assist OCR capture using EasyOCR (emits capture_assist.text)"
     input_schema:
       type: object
       properties: {}
@@ -132,7 +132,7 @@ tools:
     module: tools.tool.assist_control
     class: null
     enabled: true
-    desc: "Stop assist OCR"
+    desc: "Stop assist OCR capture"
     input_schema:
       type: object
       properties: {}


### PR DESCRIPTION
## Summary
- allow basic STT and MicTrans to run simultaneously by tracking separate processes
- expose `stt.start/stop` and `ocr.start/stop` in the tool gateway
- log `overlay.toast` events to avoid missing-subscriber warnings and provide console feedback
- clarify tool-call schema so STT/OCR (VLM) are distinct from MicTrans voice input and EasyOCR Capture Assist

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement torch>=2.1.0)*
- `pytest -q` *(fails: PortAudio library not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbcceb0ea4833395896d5cd23629e1