### PR TITLE
Mirror agent toasts to overlay

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -83,3 +83,4 @@
 - Tool call schema switched to snake_case with clear STT/OCR vs MicTrans/Capture Assist descriptions so local LLMs don't confuse subtitle translation with voice input or EasyOCR capture; prompts, tool configs, and docs updated accordingly.
 - Overlay sink now routes overlay.* events to the dedicated /overlay/event endpoint so toast messages appear on the Luna overlay.
 - MicTrans restarts now terminate any existing process before relaunching on repeated start events.
+- Toast notifications via agent.sinks.toast_notify now also post overlay.toast events so server toasts appear in the Luna overlay. Some modules still call their own overlay toasts; consolidation and deduplication remain.

--- a/agent/sinks.py
+++ b/agent/sinks.py
@@ -1,5 +1,15 @@
 from loguru import logger
 import threading
+import os
+import requests as _rq
+
+_EVENT_URL = (
+    os.environ.get("EVENT_URL")
+    or os.environ.get("AGENT_EVENT_URL")
+    or os.environ.get("OVERLAY_EVENT_URL")
+    or "http://127.0.0.1:8350/event"
+)
+_EVENT_KEY = os.environ.get("EVENT_KEY") or os.environ.get("AGENT_EVENT_KEY")
 
 def _toast_win10(title: str, msg: str) -> bool:
     try:
@@ -21,8 +31,32 @@ def _toast_winotify(title: str, msg: str) -> bool:
         logger.debug(f"[winotify] fallback due to: {e}")
         return False
 
+def _post_event(_type: str, _payload: dict, _prio: int = 5) -> None:
+    try:
+        headers = {"Content-Type": "application/json"}
+        if _EVENT_KEY:
+            headers["X-Agent-Key"] = _EVENT_KEY
+        _rq.post(
+            _EVENT_URL,
+            json={"type": _type, "payload": _payload, "priority": _prio},
+            headers=headers,
+            timeout=3,
+        )
+    except Exception:
+        pass
+
+def _overlay_toast(message: str, title: str) -> None:
+    message = (message or "").strip()
+    if not message:
+        return
+    if len(message) > 240:
+        message = message[:239] + "…"
+    _post_event("overlay.toast", {"title": title, "text": message})
+
 def toast_notify(title: str, msg: str):
     """Threaded toast notification helper (non-blocking)."""
+    _overlay_toast(msg, title)
+
     def _run():
         if _toast_win10(title, msg):
             return

--- a/tests/test_sinks_overlay.py
+++ b/tests/test_sinks_overlay.py
@@ -1,0 +1,10 @@
+import agent.sinks as sinks
+
+
+def test_toast_notify_posts_overlay(monkeypatch):
+    events = []
+    monkeypatch.setattr(sinks, "_post_event", lambda t, p, prio=5: events.append((t, p, prio)))
+    monkeypatch.setattr(sinks, "_toast_win10", lambda t, m: True)
+    monkeypatch.setattr(sinks, "_toast_winotify", lambda t, m: True)
+    sinks.toast_notify("Title", "Hello")
+    assert events == [("overlay.toast", {"title": "Title", "text": "Hello"}, 5)]


### PR DESCRIPTION
## Summary
- Post `overlay.toast` events when `toast_notify` is called so the Luna Overlay displays the same messages as local system toasts.
- Add regression test for overlay forwarding.
- Log update noting that some tools may still duplicate toasts until consolidated.

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement torch>=2.1.0)*
- `pytest -q` *(fails: OSError: PortAudio library not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd864e02c833397d1b36070c6513d