### PR TITLE
feat: forward OCR events to overlay

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -84,3 +84,4 @@
 - Overlay sink now routes overlay.* events to the dedicated /overlay/event endpoint so toast messages appear on the Luna overlay.
 - MicTrans restarts now terminate any existing process before relaunching on repeated start events.
 - Toast notifications via agent.sinks.toast_notify now also post overlay.toast events so server toasts appear in the Luna overlay. Some modules still call their own overlay toasts; consolidation and deduplication remain.
+- Overlay sink now forwards generic `ocr.text` events as `ocr.result` and uses `capture_assist.result` for EasyOCR outputs so the Luna overlay shows both standard and assist OCR results.

--- a/agent/plugins/overlay_sink.py
+++ b/agent/plugins/overlay_sink.py
@@ -153,20 +153,24 @@ class EnhancedOverlaySink(BasePlugin):
             }
         }
 
-    def _format_ocr_event(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+    def _format_ocr_event(self, event_type: str, payload: Dict[str, Any]) -> Dict[str, Any]:
         """OCR 이벤트 포맷팅"""
         text = payload.get("text", "") or payload.get("ocr", "")
         bbox = payload.get("bbox", [])
         confidence = payload.get("confidence", 0)
-        
+
         display_text = self._truncate_text(text)
-        
+
         # 좌표 정보가 있으면 추가
         if bbox and len(bbox) >= 4:
             display_text += f" 📍({bbox[0]:.0f},{bbox[1]:.0f})"
-        
+
+        evt_type = (
+            "capture_assist.result" if event_type.startswith("capture_assist.") else "ocr.result"
+        )
+
         return {
-            "type": "ocr.result",
+            "type": evt_type,
             "payload": {
                 "text": display_text,
                 "bbox": bbox,
@@ -263,7 +267,7 @@ class EnhancedOverlaySink(BasePlugin):
             if event_type.startswith("stt.") or event_type.startswith("mictrans."):
                 formatted_event = self._format_stt_event(payload)
             elif event_type.startswith("ocr.") or event_type.startswith("capture_assist."):
-                formatted_event = self._format_ocr_event(payload)
+                formatted_event = self._format_ocr_event(event_type, payload)
             elif event_type.startswith("llm.") or event_type.startswith("lm."):
                 formatted_event = self._format_llm_event(payload)
             elif event_type.startswith("web.search"):

--- a/tests/test_overlay_sink.py
+++ b/tests/test_overlay_sink.py
@@ -16,7 +16,7 @@ def test_capture_assist_event_forwarded(monkeypatch):
     event = Event(type="capture_assist.text", payload={"text": "hello", "assist": True})
     asyncio.run(sink.handle(event))
 
-    assert captured['payload']['type'] == 'ocr.result'
+    assert captured['payload']['type'] == 'capture_assist.result'
     inner = captured['payload']['payload']
     assert inner['text'] == 'hello'
     assert inner['assist'] is True
@@ -39,3 +39,20 @@ def test_mictrans_event_forwarded(monkeypatch):
     assert inner['original'] == 'hi'
     assert inner['translation'] == '안녕'
     assert '안녕' in inner['text']
+
+
+def test_ocr_event_forwarded(monkeypatch):
+    sink = EnhancedOverlaySink()
+    captured = {}
+
+    async def fake_post(url, payload):
+        captured['payload'] = payload
+        return True
+
+    sink._post_with_retry = fake_post  # type: ignore
+    event = Event(type="ocr.text", payload={"text": "generic"})
+    asyncio.run(sink.handle(event))
+
+    assert captured['payload']['type'] == 'ocr.result'
+    inner = captured['payload']['payload']
+    assert inner['text'] == 'generic'


### PR DESCRIPTION
## Summary
- Forward generic `ocr.text` and `capture_assist.text` events to Luna overlay
- Test overlay sink forwarding for capture assist and normal OCR
- Record OCR forwarding in agent memory

## Testing
- `pip install -r requirements.txt` *(failed: Could not find a version that satisfies the requirement torch>=2.1.0)*
- `pytest -q` *(failed: PortAudio library not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbdaea82bc8333bb8b73427a211d0e