### PR TITLE
Relay capture and OCR results to overlay

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -85,3 +85,4 @@
 - MicTrans restarts now terminate any existing process before relaunching on repeated start events.
 - Toast notifications via agent.sinks.toast_notify now also post overlay.toast events so server toasts appear in the Luna overlay. Some modules still call their own overlay toasts; consolidation and deduplication remain.
 - Overlay sink now forwards generic `ocr.text` events as `ocr.result` and uses `capture_assist.result` for EasyOCR outputs so the Luna overlay shows both standard and assist OCR results.
+- overlay_app now labels capture_assist.* events by prefix so Assist-Capture and VLM OCR results relay to the overlay; ROI highlighting and deeper OCR integration still pending.

--- a/Overlay/overlay_app.py
+++ b/Overlay/overlay_app.py
@@ -105,7 +105,7 @@ class EventHandler:
             if event_type.startswith("stt.") or event_type.startswith("mictrans."):
                 success = self._handle_stt(payload)
             elif event_type.startswith("ocr.") or event_type.startswith("capture_assist."):
-                success = self._handle_ocr(payload)
+                success = self._handle_ocr(event_type, payload)
             elif event_type.startswith("web.search"):
                 success = self._handle_web_search(payload)
             elif event_type.startswith("llm.") or event_type.startswith("lm."):
@@ -170,7 +170,7 @@ class EventHandler:
         self._emit_safe(label, display_text)
         return True
     
-    def _handle_ocr(self, payload: Dict[str, Any]) -> bool:
+    def _handle_ocr(self, event_type: str, payload: Dict[str, Any]) -> bool:
         """OCR 이벤트 처리"""
         text = payload.get("text", "") or payload.get("ocr", "")
         if not text:
@@ -188,8 +188,12 @@ class EventHandler:
         confidence = payload.get("confidence", 0)
         if confidence > 0:
             display_text += f" ({confidence:.0%})"
-            
-        label = "Assist-Capture" if payload.get("assist") else "👁️ OCR"
+
+        label = (
+            "Assist-Capture"
+            if event_type.startswith("capture_assist.") or payload.get("assist")
+            else "👁️ OCR"
+        )
         self._emit_safe(label, display_text)
         return True
     

--- a/tests/test_overlay_app.py
+++ b/tests/test_overlay_app.py
@@ -1,0 +1,17 @@
+from Overlay.overlay_app import EventHandler
+
+
+def test_capture_assist_event_labeled_assist(monkeypatch):
+    handler = EventHandler(window=None)
+    emitted = []
+    handler._emit_safe = lambda who, msg: emitted.append((who, msg))
+    assert handler.handle_event("capture_assist.result", {"text": "hello"}) is True
+    assert emitted == [("Assist-Capture", "hello")]
+
+
+def test_ocr_event_labeled_ocr(monkeypatch):
+    handler = EventHandler(window=None)
+    emitted = []
+    handler._emit_safe = lambda who, msg: emitted.append((who, msg))
+    assert handler.handle_event("ocr.result", {"text": "hola"}) is True
+    assert emitted == [("👁️ OCR", "hola")]


### PR DESCRIPTION
## Summary
- Ensure overlay event handler forwards capture_assist and OCR events using the event type prefix
- Add tests verifying overlay labels for Assist-Capture and OCR results
- Log work in agent memory

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies torch)*
- `pytest -q` *(fails: PortAudio library not found; libGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bbe0dbd6bc8333883048afddc95592