### PR TITLE
feat: send OCR and capture assist results to overlay

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -86,3 +86,4 @@
 - Toast notifications via agent.sinks.toast_notify now also post overlay.toast events so server toasts appear in the Luna overlay. Some modules still call their own overlay toasts; consolidation and deduplication remain.
 - Overlay sink now forwards generic `ocr.text` events as `ocr.result` and uses `capture_assist.result` for EasyOCR outputs so the Luna overlay shows both standard and assist OCR results.
 - overlay_app now labels capture_assist.* events by prefix so Assist-Capture and VLM OCR results relay to the overlay; ROI highlighting and deeper OCR integration still pending.
+- Capture Assist and OCR now rely on overlay-only toasts and _post_event, avoiding agent server logs; advanced overlay integrations remain.

--- a/Capture-assist/capture_assist.py
+++ b/Capture-assist/capture_assist.py
@@ -74,14 +74,8 @@ def _overlay_toast(message: str, title: str = "Assist-Capture") -> None:
 
 
 def _notify(msg: str) -> None:
-    """Display a toast notification locally and via overlay."""
+    """Display a toast notification via the overlay only."""
     _overlay_toast(msg)
-    try:
-        from agent.sinks import toast_notify
-
-        toast_notify("Assist-Capture", msg)
-    except Exception:
-        pass
 
 
 def _refine_with_jan(text: str) -> str:

--- a/OCR/main.py
+++ b/OCR/main.py
@@ -11,7 +11,7 @@ LM Studio OCR → Translation Snipping Tool
 
 완료 시
 - 결과 창은 띄우지 않음 (요청사항)
-- 번역 결과를 클립보드로 복사 + Windows 토스트만 표시
+- 번역 결과를 클립보드로 복사 + 오버레이 토스트만 표시
 """
 
 from __future__ import annotations
@@ -55,6 +55,16 @@ def _post_event(_type, _payload, _prio=5):
         )
     except Exception:
         pass
+
+
+def _overlay_toast(message: str, title: str = "OCR") -> None:
+    """Send a toast message to the Lunar overlay."""
+    message = (message or "").strip()
+    if not message:
+        return
+    if len(message) > 240:
+        message = message[:239] + "…"
+    _post_event("overlay.toast", {"title": title, "text": message})
 
 
 import requests
@@ -498,15 +508,6 @@ class MainWindow(QMainWindow):
             return self._truncate(f"OCR:\n{ocr_text}\n\nTRANSLATION:\n{translated}", 260)
         return self._truncate(translated or ocr_text)
 
-    def _show_windows_notification(self, title: str, message: str):
-        # Lunar Bridge → Overlay toast
-        _post_event("overlay.toast", {"title": title, "text": message})
-        try:
-            from win10toast import ToastNotifier  # type: ignore
-            ToastNotifier().show_toast(title, message, duration=8, threaded=True)
-            return
-        except Exception:
-            pass
 
     # ---------- 이벤트 ----------
     def on_save(self):
@@ -611,9 +612,9 @@ class MainWindow(QMainWindow):
         )
 
         if self.cfg.get("notify_on_finish", True):
-            self._show_windows_notification(
-                "번역 완료 (클립보드 복사됨)",
+            _overlay_toast(
                 self._build_notify_text(ocr_clean, trans_clean),
+                "번역 완료 (클립보드 복사됨)",
             )
 
     def on_error(self, msg: str):


### PR DESCRIPTION
## Summary
- route Capture Assist notifications solely through the overlay toast bridge to avoid agent server logs
- add shared overlay toast helper to OCR tool and use it for completion notifications

## Testing
- `pip install -r requirements.txt` *(fails: No matching distribution found for torch>=2.1.0)*
- `pytest -q` *(fails: PortAudio library not found; libGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bbe31843448333b375c109a8ff62cc