### PR TITLE
Normalize overlay text events

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -87,3 +87,4 @@
 - Overlay sink now forwards generic `ocr.text` events as `ocr.result` and uses `capture_assist.result` for EasyOCR outputs so the Luna overlay shows both standard and assist OCR results.
 - overlay_app now labels capture_assist.* events by prefix so Assist-Capture and VLM OCR results relay to the overlay; ROI highlighting and deeper OCR integration still pending.
 - Capture Assist and OCR now rely on overlay-only toasts and _post_event, avoiding agent server logs; advanced overlay integrations remain.
+- Overlay event handler now normalizes `stt.text`, `ocr.text`, and `capture_assist.text` events so OCR and STT results always append to the panel; richer source labeling and OCR-specific UI hooks still need work.

--- a/Overlay/overlay_app.py
+++ b/Overlay/overlay_app.py
@@ -99,7 +99,16 @@ class EventHandler:
             
             if self.debug_mode:
                 logger.info(f"[event] Processing {event_type}: {payload}")
-            
+
+            # 공통 텍스트 이벤트 정규화
+            if event_type in ("stt.text", "ocr.text", "capture_assist.text"):
+                text = payload.get("text") or payload.get("translation") or ""
+                if text:
+                    source = payload.get("source", event_type.split('.')[0])
+                    self._emit_safe(source, text)
+                    return True
+                return False
+
             # 이벤트 타입별 처리
             success = False
             if event_type.startswith("stt.") or event_type.startswith("mictrans."):

--- a/tests/test_overlay_app.py
+++ b/tests/test_overlay_app.py
@@ -15,3 +15,19 @@ def test_ocr_event_labeled_ocr(monkeypatch):
     handler._emit_safe = lambda who, msg: emitted.append((who, msg))
     assert handler.handle_event("ocr.result", {"text": "hola"}) is True
     assert emitted == [("👁️ OCR", "hola")]
+
+
+def test_raw_text_events(monkeypatch):
+    handler = EventHandler(window=None)
+    emitted = []
+    handler._emit_safe = lambda who, msg: emitted.append((who, msg))
+
+    assert handler.handle_event("stt.text", {"text": "hi"}) is True
+    assert handler.handle_event("ocr.text", {"text": "scan"}) is True
+    assert handler.handle_event("capture_assist.text", {"text": "cap", "source": "easy"}) is True
+
+    assert emitted == [
+        ("stt", "hi"),
+        ("ocr", "scan"),
+        ("easy", "cap"),
+    ]


### PR DESCRIPTION
## Summary
- Normalize `stt.text`, `ocr.text`, and `capture_assist.text` at overlay ingress so all text events append to the panel
- Add regression test for raw text events hitting the overlay handler
- Note work in agent memory log

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement torch>=2.1.0)*
- `pytest -q` *(fails: PortAudio library not found; libGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bbeb89c0dc8333a81d40ca0d1c9f11