### PR TITLE
Deduplicate overlay toast events

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -88,3 +88,4 @@
 - overlay_app now labels capture_assist.* events by prefix so Assist-Capture and VLM OCR results relay to the overlay; ROI highlighting and deeper OCR integration still pending.
 - Capture Assist and OCR now rely on overlay-only toasts and _post_event, avoiding agent server logs; advanced overlay integrations remain.
 - Overlay event handler now normalizes `stt.text`, `ocr.text`, and `capture_assist.text` events so OCR and STT results always append to the panel; richer source labeling and OCR-specific UI hooks still need work.
+- Overlay toast handler now tracks recent messages to avoid speaking duplicate notifications; full dedup across all modules still pending.

--- a/Overlay/overlay_app.py
+++ b/Overlay/overlay_app.py
@@ -462,7 +462,7 @@ class EventHandler:
             if title in filtered_titles:
                 return False
                 
-            if text:
+            if text and not self._is_duplicate_message(text):
                 self._emit_safe(f"📢 {title}", text)
                 return True
         return False

--- a/Overlay/overlay_app_enhanced.py
+++ b/Overlay/overlay_app_enhanced.py
@@ -85,9 +85,23 @@ class EnhancedEventHandler:
         self.plugin_manager = plugin_manager
         self.stats = EventStats()
         self.debug_mode = False
+        # 최근 표시한 토스트를 추적하여 중복 방지
+        self._recent_toasts: Dict[str, float] = {}
         
     def set_debug_mode(self, enabled: bool):
         self.debug_mode = enabled
+
+    def _is_duplicate_toast(self, text: str) -> bool:
+        """5초 내에 동일한 토스트가 이미 처리되었는지 확인"""
+        import time, hashlib
+        now = time.time()
+        text_hash = hashlib.md5(text.encode('utf-8')).hexdigest()
+        # 오래된 항목 정리
+        self._recent_toasts = {h: t for h, t in self._recent_toasts.items() if now - t <= 5}
+        if text_hash in self._recent_toasts:
+            return True
+        self._recent_toasts[text_hash] = now
+        return False
         
     def handle_event(self, event_type: str, payload: Dict[str, Any]) -> bool:
         """향상된 이벤트 처리 - 플러그인 우선"""
@@ -289,7 +303,7 @@ class EnhancedEventHandler:
         if event_type == "overlay.toast":
             title = payload.get("title", "알림")
             text = payload.get("text", "")
-            if text:
+            if text and not self._is_duplicate_toast(text):
                 self._emit_safe(f"📢 {title}", text)
                 return True
         return False

--- a/tests/test_overlay_dedup.py
+++ b/tests/test_overlay_dedup.py
@@ -1,0 +1,24 @@
+from types import SimpleNamespace
+
+from Overlay.overlay_app import EventHandler
+
+
+class DummyEmitter:
+    def __init__(self):
+        self.calls = []
+
+    def emit(self, who, msg):
+        self.calls.append((who, msg))
+
+
+def test_overlay_toast_dedup():
+    window = SimpleNamespace(appended=DummyEmitter())
+    handler = EventHandler(window)
+
+    handler._handle_overlay_event("overlay.toast", {"title": "T", "text": "hello"})
+    handler._handle_overlay_event("overlay.toast", {"title": "T", "text": "hello"})
+
+    assert len(window.appended.calls) == 1
+
+    handler._handle_overlay_event("overlay.toast", {"title": "T", "text": "bye"})
+    assert len(window.appended.calls) == 2


### PR DESCRIPTION
## Summary
- Track recent overlay toast messages and ignore duplicates within 5 seconds to prevent repeated speech
- Apply duplicate filtering in enhanced and standard overlay handlers
- Add tests verifying that identical overlay.toast events emit only once

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement torch>=2.1.0)*
- `pytest -q` *(fails: PortAudio library not found; libGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf95f10f88333b535dd3f6599f904