### PR TITLE
Handle varied translator response schemas

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -89,3 +89,4 @@
 - Capture Assist and OCR now rely on overlay-only toasts and _post_event, avoiding agent server logs; advanced overlay integrations remain.
 - Overlay event handler now normalizes `stt.text`, `ocr.text`, and `capture_assist.text` events so OCR and STT results always append to the panel; richer source labeling and OCR-specific UI hooks still need work.
 - Overlay toast handler now tracks recent messages to avoid speaking duplicate notifications; full dedup across all modules still pending.
+- Translator plugin now tolerates varied LLM response schemas (message/content, content, or text) so translations no longer return `None` when the structure differs. Further guardrails and richer translation features remain.

--- a/agent/plugins/translator_plugin.py
+++ b/agent/plugins/translator_plugin.py
@@ -43,7 +43,18 @@ class TranslatorPlugin(BasePlugin):
             r = await client.post(f"{endpoint}/chat/completions", headers=headers, json=payload)
             r.raise_for_status()
             data = r.json()
-            return (data["choices"][0]["message"]["content"] or "").strip()
+            try:
+                choice = data.get("choices", [{}])[0]
+                content = (
+                    choice.get("message", {}).get("content")
+                    or choice.get("content")
+                    or choice.get("text")
+                    or ""
+                )
+                return content.strip() or None
+            except Exception as e:
+                logger.error(f"translate parse error: {e}; data={data}")
+                return None
 
     async def _translate(self, text: str, target_lang: str = "ko") -> Optional[str]:
         cfg = self.ctx.config.get("translate", {})


### PR DESCRIPTION
## Summary
- Parse translator responses robustly so non-standard LLM schemas don't yield `None`
- Record translator parsing improvement in working memory

## Testing
- ⚠️ `pip install -r requirements.txt` (missing torch dependency)
- ⚠️ `pytest -q` (PortAudio library and libGL missing)


------
https://chatgpt.com/codex/tasks/task_e_68bbfad23f588333be2af32c35bdf7fe