### PR TITLE
fix: prevent duplicate STT/OCR overlay entries

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -90,3 +90,4 @@
 - Overlay event handler now normalizes `stt.text`, `ocr.text`, and `capture_assist.text` events so OCR and STT results always append to the panel; richer source labeling and OCR-specific UI hooks still need work.
 - Overlay toast handler now tracks recent messages to avoid speaking duplicate notifications; full dedup across all modules still pending.
 - Translator plugin now tolerates varied LLM response schemas (message/content, content, or text) so translations no longer return `None` when the structure differs. Further guardrails and richer translation features remain.
+- OCR, MicTrans, and Capture Assist plugins now avoid republishing cleaned events to prevent overlay duplication. Further wake-word handling and deep assist integration remain.

--- a/agent/plugins/capture_assist_plugin.py
+++ b/agent/plugins/capture_assist_plugin.py
@@ -12,5 +12,6 @@ class CaptureAssistPlugin(BasePlugin):
         text = event.payload.get("text", "")
         text = text.replace("\u200b", "").strip()
         event.payload["text"] = text
-        await self.ctx.bus.publish(event)  # 재전송 → translator가 수신
-        logger.debug(f"[{self.name}] cleaned and republished capture_assist.text")
+        # 후속 플러그인에 동일 이벤트가 전달되므로 재전송은 필요 없다.
+        # 재전송 시 Overlay에 중복 표기가 발생하므로 제거한다.
+        logger.debug(f"[{self.name}] cleaned capture_assist.text")

--- a/agent/plugins/mictrans_plugin.py
+++ b/agent/plugins/mictrans_plugin.py
@@ -16,5 +16,5 @@ class MicTransPlugin(BasePlugin):
             if not dedup or dedup[-1] != p:
                 dedup.append(p)
         event.payload["text"] = " ".join(dedup)
-        await self.ctx.bus.publish(event)
-        logger.debug(f"[{self.name}] cleaned and republished mictrans.text")
+        # 이벤트 객체는 그대로 전달되므로 재전송하지 않는다.
+        logger.debug(f"[{self.name}] cleaned mictrans.text")

--- a/agent/plugins/ocr_plugin.py
+++ b/agent/plugins/ocr_plugin.py
@@ -13,7 +13,7 @@ class OCRPlugin(BasePlugin):
         text = event.payload.get("text", "")
         # 간단한 노이즈 제거
         text = text.replace("\u200b", "").strip()
-        # 다음 단계로 번역을 유도하기 위해 translator가 듣는 동일 타입을 다시 publish
         event.payload["text"] = text
-        await self.ctx.bus.publish(event)  # 재전송 → translator가 수신
-        logger.debug(f"[{self.name}] cleaned and republished ocr.text")
+        # 이벤트는 원본 객체가 전달되므로 재전송 없이도 후속 플러그인이
+        # 정제된 텍스트를 수신한다. 재발행하면 Overlay에 중복 표시되므로 생략.
+        logger.debug(f"[{self.name}] cleaned ocr.text")


### PR DESCRIPTION
## Summary
- stop OCR plugin from republishing cleaned events that caused duplicates
- remove redundant reposting in MicTrans and Capture Assist plugins
- log removal in Agent memory for future agents

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: libGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb59754208333abcba1d65b6f7c98