### PR TITLE
fix: dedupe stt translations

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -91,3 +91,4 @@
 - Overlay toast handler now tracks recent messages to avoid speaking duplicate notifications; full dedup across all modules still pending.
 - Translator plugin now tolerates varied LLM response schemas (message/content, content, or text) so translations no longer return `None` when the structure differs. Further guardrails and richer translation features remain.
 - OCR, MicTrans, and Capture Assist plugins now avoid republishing cleaned events to prevent overlay duplication. Further wake-word handling and deep assist integration remain.
+- Translator plugin now collapses duplicate STT translations and skips overlay toasts for stt.* events, preventing repeated Korean output and ensuring OCR results continue to reach the overlay.

--- a/agent/plugins/translator_plugin.py
+++ b/agent/plugins/translator_plugin.py
@@ -9,6 +9,18 @@ THINK_RE = re.compile(r"<think>.*?</think>\s*", re.DOTALL)
 def strip_think(text: str) -> str:
     return THINK_RE.sub("", text)
 
+
+def dedup_translation(text: str) -> str:
+    """Remove duplicated lines in translation output.
+
+    Some STT translations return the same sentence twice (often separated by a
+    newline). If two non-empty lines are identical, collapse them into a single
+    line so the overlay and TTS don't repeat the message."""
+    lines = [l.strip() for l in text.splitlines() if l.strip()]
+    if len(lines) == 2 and lines[0] == lines[1]:
+        return lines[0]
+    return text
+
 class TranslatorPlugin(BasePlugin):
     name = "translator"
     handles = [
@@ -133,11 +145,15 @@ class TranslatorPlugin(BasePlugin):
         if not translated:
             # 실패 시: 원문을 그대로 토스트/로그(앱은 멈추지 않게)
             fallback = (strip_think(text) or text)[:180]
-            self.ctx.sinks.write_log(f"[{self.name}] translate failed; pass-through: {fallback}",
-                                     self.ctx.config["sinks"].get("log_file"))
+            self.ctx.sinks.write_log(
+                f"[{self.name}] translate failed; pass-through: {fallback}",
+                self.ctx.config["sinks"].get("log_file"),
+            )
             if self.ctx.config["sinks"].get("toast", True):
                 self.ctx.sinks.toast_notify("번역 실패 (원문 표시)", fallback)
             return
+
+        translated = dedup_translation(translated)
 
         msg = f"[{self.name}] {event.type} → 번역 완료: {translated[:180]}..."
         self.ctx.sinks.write_log(msg, self.ctx.config["sinks"].get("log_file"))
@@ -145,11 +161,14 @@ class TranslatorPlugin(BasePlugin):
         await self.ctx.bus.publish(
             Event(type="translator.text", payload={"text": translated, "source": event.type})
         )
-        await self.ctx.bus.publish(
-            Event(
-                type="overlay.toast",
-                payload={"title": "번역 완료", "text": translated[:64]},
+
+        # STT 이벤트의 경우 overlay.toast를 생략하여 중복 안내/음성을 방지
+        if not event.type.startswith("stt."):
+            await self.ctx.bus.publish(
+                Event(
+                    type="overlay.toast",
+                    payload={"title": "번역 완료", "text": translated[:64]},
+                )
             )
-        )
-        if self.ctx.config["sinks"].get("toast", True):
-            self.ctx.sinks.toast_notify("번역 완료", translated[:64])
+            if self.ctx.config["sinks"].get("toast", True):
+                self.ctx.sinks.toast_notify("번역 완료", translated[:64])

--- a/tests/test_translator_dedup.py
+++ b/tests/test_translator_dedup.py
@@ -1,0 +1,10 @@
+from agent.plugins.translator_plugin import dedup_translation
+
+
+def test_dedup_translation_collapses_duplicate_lines():
+    assert dedup_translation("안녕\n안녕") == "안녕"
+
+
+def test_dedup_translation_keeps_unique_lines():
+    text = "안녕\n하세요"
+    assert dedup_translation(text) == text


### PR DESCRIPTION
## Summary
- collapse duplicated STT translation lines to avoid double speech
- skip overlay.toast for stt.* events to prevent repeated output
- add tests for translation dedup

## Testing
- `pip install -r requirements.txt` *(failed: Could not find a version that satisfies the requirement torch>=2.1.0)*
- `pytest -q` *(failed: OSError: PortAudio library not found; ImportError: libGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bcbed86e8483339796857c300c9b90