### PR TITLE
feat: streamline STT overlay output and dual-post OCR events

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -92,3 +92,4 @@
 - Translator plugin now tolerates varied LLM response schemas (message/content, content, or text) so translations no longer return `None` when the structure differs. Further guardrails and richer translation features remain.
 - OCR, MicTrans, and Capture Assist plugins now avoid republishing cleaned events to prevent overlay duplication. Further wake-word handling and deep assist integration remain.
 - Translator plugin now collapses duplicate STT translations and skips overlay toasts for stt.* events, preventing repeated Korean output and ensuring OCR results continue to reach the overlay.
+- STT translations now output directly to overlay (skipping Tiny preview models), and OCR/Capture Assist post results to both agent server and overlay.

--- a/Capture-assist/capture_assist.py
+++ b/Capture-assist/capture_assist.py
@@ -37,30 +37,31 @@ except Exception:  # pragma: no cover - runtime dependency
     easyocr = None
 
 # ---- Luna Agent bridge (공통) ----
-_EVENT_URL = (
-    os.environ.get("EVENT_URL")
-    or os.environ.get("AGENT_EVENT_URL")
-    or os.environ.get("OVERLAY_EVENT_URL")
-    or "http://127.0.0.1:8350/event"
+_AGENT_EVENT_URL = (
+    os.environ.get("AGENT_EVENT_URL")
+    or os.environ.get("EVENT_URL")
+    or "http://127.0.0.1:8765/event"
 )
+_OVERLAY_EVENT_URL = os.environ.get("OVERLAY_EVENT_URL") or "http://127.0.0.1:8350/event"
 _EVENT_KEY = os.environ.get("EVENT_KEY") or os.environ.get("AGENT_EVENT_KEY")
 
 LOG_PATH = pathlib.Path(__file__).with_name("capture_assist.log")
 
 
 def _post_event(_type: str, _payload: dict, _prio: int = 5) -> None:
-    try:
-        headers = {"Content-Type": "application/json"}
-        if _EVENT_KEY:
-            headers["X-Agent-Key"] = _EVENT_KEY
-        _rq.post(
-            _EVENT_URL,
-            json={"type": _type, "payload": _payload, "priority": _prio},
-            headers=headers,
-            timeout=3,
-        )
-    except Exception:
-        pass
+    headers = {"Content-Type": "application/json"}
+    if _EVENT_KEY:
+        headers["X-Agent-Key"] = _EVENT_KEY
+    for url in (_AGENT_EVENT_URL, _OVERLAY_EVENT_URL):
+        try:
+            _rq.post(
+                url,
+                json={"type": _type, "payload": _payload, "priority": _prio},
+                headers=headers,
+                timeout=3,
+            )
+        except Exception:
+            pass
 
 
 def _overlay_toast(message: str, title: str = "Assist-Capture") -> None:

--- a/OCR/main.py
+++ b/OCR/main.py
@@ -27,34 +27,29 @@ from pathlib import Path
 # ---- Luna Agent bridge (공통) ----
 import requests as _rq
 # 이벤트 전송 URL: Overlay 또는 Agent로 전달
-_EVENT_URL = (
-    os.environ.get("EVENT_URL")
-    or os.environ.get("AGENT_EVENT_URL")
-    or os.environ.get("OVERLAY_EVENT_URL")
-    or "http://127.0.0.1:8350/event"
+_AGENT_EVENT_URL = (
+    os.environ.get("AGENT_EVENT_URL")
+    or os.environ.get("EVENT_URL")
+    or "http://127.0.0.1:8765/event"
 )
+_OVERLAY_EVENT_URL = os.environ.get("OVERLAY_EVENT_URL") or "http://127.0.0.1:8350/event"
 _EVENT_KEY = os.environ.get("EVENT_KEY") or os.environ.get("AGENT_EVENT_KEY")
 
-# 환경변수 fallback (별도 지정이 없을 때 Overlay로 직접 전송)
-if not os.environ.get("EVENT_URL") and not os.environ.get("AGENT_EVENT_URL"):
-    os.environ["EVENT_URL"] = _EVENT_URL
-    print("[OCR] Set fallback EVENT_URL")
-print(f"[OCR] Using EVENT_URL: {os.environ.get('EVENT_URL') or _EVENT_URL}")
-
 def _post_event(_type, _payload, _prio=5):
-    """Send OCR/translation results to overlay or agent."""
-    try:
-        headers = {"Content-Type": "application/json"}
-        if _EVENT_KEY:
-            headers["X-Agent-Key"] = _EVENT_KEY
-        _rq.post(
-            _EVENT_URL,
-            json={"type": _type, "payload": _payload, "priority": _prio},
-            headers=headers,
-            timeout=3,
-        )
-    except Exception:
-        pass
+    """Send OCR/translation results to both agent server and overlay."""
+    headers = {"Content-Type": "application/json"}
+    if _EVENT_KEY:
+        headers["X-Agent-Key"] = _EVENT_KEY
+    for url in (_AGENT_EVENT_URL, _OVERLAY_EVENT_URL):
+        try:
+            _rq.post(
+                url,
+                json={"type": _type, "payload": _payload, "priority": _prio},
+                headers=headers,
+                timeout=3,
+            )
+        except Exception:
+            pass
 
 
 def _overlay_toast(message: str, title: str = "OCR") -> None:

--- a/Overlay/overlay_app.py
+++ b/Overlay/overlay_app.py
@@ -266,7 +266,7 @@ class EventHandler:
         # 동시 수신 메시지 필터링 (3ms 내)
         if not self._should_process_concurrent_message(text, source_type):
             return False
-        
+
         # 모드 추적 및 필터링
         if is_assist or "mictrans" in source.lower():
             mode = "mictrans"
@@ -282,15 +282,16 @@ class EventHandler:
                 return False
             self.active_modes.add(mode)
             self._update_mode_activity(mode)
-            
-        # 기본 텍스트
-        display_text = text
-        
-        # 번역이 있으면 추가
-        translation = payload.get("translation", "")
-        if translation and translation.strip() != text:
-            display_text += f"\n🔄 {translation}"
-        
+
+        # 프리뷰 Tiny 모델은 무시
+        model_name = (payload.get("model") or "").lower()
+        if payload.get("preview") and "tiny" in model_name:
+            return False
+
+        # 번역이 있으면 그대로 사용, 아니면 원문 사용
+        translation = payload.get("translation", "").strip()
+        display_text = translation or text
+
         # 신뢰도 표시
         confidence = payload.get("confidence", 0)
         if confidence > 0 and confidence < 0.8:
@@ -302,9 +303,8 @@ class EventHandler:
             display_text += f" [{language}]"
 
         # 사용된 STT 모델 정보
-        model = payload.get("model", "")
-        if model:
-            display_text += f" ({model})"
+        if model_name:
+            display_text += f" ({model_name})"
 
         label = "Assist-MicTrans" if payload.get("assist") else "🎤 STT"
         self._emit_safe(label, display_text)

--- a/agent/plugins/overlay_sink.py
+++ b/agent/plugins/overlay_sink.py
@@ -127,22 +127,19 @@ class EnhancedOverlaySink(BasePlugin):
 
     def _format_stt_event(self, payload: Dict[str, Any]) -> Dict[str, Any]:
         """STT 이벤트 포맷팅"""
+        model = (payload.get("model") or "").lower()
+        if payload.get("preview") and "tiny" in model:
+            return None
+
         text = payload.get("text", "")
         translation = payload.get("translation", "")
         confidence = payload.get("confidence", 0)
-        
-        # 메인 텍스트
-        display_text = self._truncate_text(text)
-        
-        # 번역이 있고 원문과 다르면 추가
-        if translation and translation.strip() != text.strip():
-            trans_text = self._truncate_text(translation, max_len=100)
-            display_text += f"\n🔄 {trans_text}"
-        
-        # 신뢰도가 낮으면 표시
+
+        display_text = self._truncate_text(translation or text)
+
         if confidence > 0 and confidence < 0.7:
             display_text += f" (신뢰도: {confidence:.0%})"
-        
+
         return {
             "type": "stt.result",
             "payload": {
@@ -150,8 +147,8 @@ class EnhancedOverlaySink(BasePlugin):
                 "original": text,
                 "translation": translation,
                 "confidence": confidence,
-                "assist": payload.get("assist", False)
-            }
+                "assist": payload.get("assist", False),
+            },
         }
 
     def _format_ocr_event(self, event_type: str, payload: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- show STT translations directly in overlay and ignore preview Tiny model results
- forward OCR and capture assist text to both agent server and overlay
- record STT/OCR changes in agent memory

## Testing
- `pip install -r requirements.txt` (fails: Could not find a version that satisfies torch>=2.1.0)
- `pytest -q` (fails: PortAudio library not found; libGL.so.1 missing)


------
https://chatgpt.com/codex/tasks/task_e_68bcc01d934c83339a398ca50192f2a5