### PR TITLE
Relay server toasts via overlay sink

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -97,3 +97,6 @@
 
 - agent.server._toast_handler now republishes toast events with a _relay flag so overlay sinks reliably display server toasts. Further deduplication across modules remains.
 - Overlay now ignores direct `stt.*`, `mictrans.*`, `ocr.*`, and `capture_assist.*` events so STT/OCR tools relay messages through the agent server. Cross-module toast deduplication still outstanding.
+
+- overlay_sink now forwards relayed overlay.toast events from agent.server._toast_handler so server toasts appear once in the overlay; cross-module deduplication still pending.
+- Overlay sink now relays server toast messages while a new overlay toast plugin shows relayed events as Windows notifications.

--- a/agent/plugins/overlay_sink.py
+++ b/agent/plugins/overlay_sink.py
@@ -271,10 +271,13 @@ class EnhancedOverlaySink(BasePlugin):
             elif event_type.startswith("web.search"):
                 formatted_event = self._format_search_event(payload)
             elif event_type.startswith("overlay."):
-                # 직접 전달 (토스트 등)
+                # 토스트 등 overlay.* 이벤트는 서버의 _toast_handler가
+                # _relay 플래그를 붙여 재게시한 것만 전달하여 중복을 방지
+                if event_type == "overlay.toast" and not payload.get("_relay"):
+                    return
                 formatted_event = {
                     "type": event_type,
-                    "payload": payload
+                    "payload": payload,
                 }
             
             if not formatted_event:

--- a/agent/plugins/overlay_toast_plugin.py
+++ b/agent/plugins/overlay_toast_plugin.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""Overlay toast plugin: show Windows toast notifications for relayed messages.
+
+The agent's server republishs :code:`overlay.toast` events with a ``_relay`` flag
+via :func:`agent.server._toast_handler`.  This plugin listens for those relayed
+messages and displays a local Windows toast so the user is notified even when
+the message originated from elsewhere.
+
+OverlaySink handles forwarding the same events to the overlay application.
+"""
+
+import asyncio
+from loguru import logger
+
+from agent.sinks import _toast_win10, _toast_winotify
+from . import BasePlugin
+
+
+class OverlayToastPlugin(BasePlugin):
+    """Display Windows toasts for relayed overlay messages."""
+
+    name = "overlay_toast"
+    handles = ["overlay.toast"]
+
+    async def handle(self, event) -> None:
+        payload = getattr(event, "payload", {}) or {}
+        # Only show toasts for events that were relayed by the server to avoid
+        # duplicating local toast_notify() calls.
+        if not payload.get("_relay"):
+            return
+
+        title = payload.get("title", "")
+        text = payload.get("text", "")
+
+        def _show() -> None:
+            if _toast_win10(title, text):
+                return
+            if _toast_winotify(title, text):
+                return
+            logger.info(f"[TOAST] {title}: {text}")
+
+        # Run the potentially blocking toast APIs in a thread.
+        await asyncio.to_thread(_show)

--- a/agent/server.py
+++ b/agent/server.py
@@ -6,11 +6,6 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from loguru import logger
 from .schemas import Event, Result, PluginEventIn
-try:
-    import httpx
-except Exception:  # pragma: no cover - optional dependency
-    httpx = None
-import requests
 
 CAPTURE_LOG_PATH = Path(__file__).resolve().parents[1] / "Capture-assist" / "capture_assist.log"
 
@@ -169,26 +164,8 @@ def create_app(ctx, plugins=None):
                     return
                 title = payload.get("title", "")
                 text = payload.get("text", "")
-                try:
-                    if httpx:
-                        async with httpx.AsyncClient(timeout=2.0) as client:
-                            await client.post(
-                                OVERLAY_TOAST_URL,
-                                json={"type": "overlay.toast", "payload": payload},
-                            )
-                    else:
-                        def _sync_post():
-                            requests.post(
-                                OVERLAY_TOAST_URL,
-                                json={"type": "overlay.toast", "payload": payload},
-                                timeout=2.0,
-                            )
-                        await asyncio.to_thread(_sync_post)
-                except Exception as e:
-                    logger.debug(f"[toast] overlay send failed: {e}")
                 logger.info(f"[toast] {title}: {text}")
-                # relay event on the bus so other subscribers (e.g., overlay sink)
-                # can also react and display the message
+                # relay event on the bus so overlay sinks can forward the message
                 try:
                     await ctx.bus.publish(
                         Event(

--- a/tests/test_overlay_sink.py
+++ b/tests/test_overlay_sink.py
@@ -56,3 +56,26 @@ def test_ocr_event_forwarded(monkeypatch):
     assert captured['payload']['type'] == 'ocr.result'
     inner = captured['payload']['payload']
     assert inner['text'] == 'generic'
+
+
+def test_overlay_toast_relay(monkeypatch):
+    sink = EnhancedOverlaySink()
+    captured = []
+
+    async def fake_post(url, payload):
+        captured.append((url, payload))
+        return True
+
+    sink._post_with_retry = fake_post  # type: ignore
+
+    # original toast without _relay should be ignored
+    event = Event(type="overlay.toast", payload={"title": "T", "text": "hi"})
+    asyncio.run(sink.handle(event))
+    assert captured == []
+
+    # relayed toast should be forwarded to overlay
+    event2 = Event(type="overlay.toast", payload={"title": "T", "text": "hi", "_relay": True})
+    asyncio.run(sink.handle(event2))
+
+    assert captured and captured[0][1]["type"] == "overlay.toast"
+    assert captured[0][1]["payload"]["title"] == "T"

--- a/tests/test_overlay_toast_plugin.py
+++ b/tests/test_overlay_toast_plugin.py
@@ -1,0 +1,26 @@
+import asyncio
+from types import SimpleNamespace
+
+from agent.plugins.overlay_toast_plugin import OverlayToastPlugin
+from agent.schemas import Event
+
+
+def test_overlay_toast_plugin_emits_toast(monkeypatch):
+    ctx = SimpleNamespace()
+    plugin = OverlayToastPlugin(ctx)
+    shown = []
+
+    def fake_win10(title, msg):
+        shown.append((title, msg))
+        return True
+
+    monkeypatch.setattr("agent.plugins.overlay_toast_plugin._toast_win10", fake_win10)
+    monkeypatch.setattr("agent.plugins.overlay_toast_plugin._toast_winotify", lambda t, m: False)
+
+    # non-relayed event should not trigger toast
+    asyncio.run(plugin.handle(Event(type="overlay.toast", payload={"title": "T", "text": "one"})))
+    assert shown == []
+
+    # relayed event should trigger toast once
+    asyncio.run(plugin.handle(Event(type="overlay.toast", payload={"title": "T", "text": "two", "_relay": True})))
+    assert shown == [("T", "two")]

--- a/tests/test_toast_handler_relay.py
+++ b/tests/test_toast_handler_relay.py
@@ -16,11 +16,7 @@ async def dispatch_all(bus: EventBus):
                     await h(e)
 
 
-def test_toast_handler_relays_to_bus(monkeypatch):
-    # prevent actual HTTP requests
-    monkeypatch.setattr(server, "httpx", None)
-    monkeypatch.setattr(server, "requests", SimpleNamespace(post=lambda *a, **k: None))
-
+def test_toast_handler_relays_to_bus():
     ctx = SimpleNamespace(config={}, bus=EventBus(dedup_window=0), assist_mode=False)
     app = create_app(ctx, plugins=[])
     relayed = []


### PR DESCRIPTION
## Summary
- forward only `_relay`-flagged `overlay.toast` events so server messages flow through `EnhancedOverlaySink`
- add `OverlayToastPlugin` to show Windows toasts for relayed overlay messages
- test plugin to ensure only relayed toasts trigger notifications

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement torch>=2.1.0)*
- `pytest -q` *(fails: OSError: PortAudio library not found; ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc99266c883338add1a4ff7349f35