### PR TITLE
feat: add overlay send plugin

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -100,3 +100,4 @@
 
 - overlay_sink now forwards relayed overlay.toast events from agent.server._toast_handler so server toasts appear once in the overlay; cross-module deduplication still pending.
 - Overlay sink now relays server toast messages while a new overlay toast plugin shows relayed events as Windows notifications.
+- Added overlay send plugin so overlay.send events republish as relayed overlay.toast messages, allowing Luna Overlay to display messages while overlay toasts show Windows notifications; cross-module deduplication still pending.

--- a/agent/plugins/overlay_send_plugin.py
+++ b/agent/plugins/overlay_send_plugin.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+"""Overlay send plugin: republish overlay messages for relay.
+
+This plugin listens for :code:`overlay.send` events and re-emits them as
+:code:`overlay.toast` events tagged with ``_relay``.  The overlay sink will then
+forward the message to the Luna Overlay application while the overlay toast
+plugin shows a local Windows notification.
+"""
+
+from loguru import logger
+
+from agent.schemas import Event
+from . import BasePlugin
+
+
+class OverlaySendPlugin(BasePlugin):
+    """Republish overlay messages so sinks and toasts handle them."""
+
+    name = "overlay_send"
+    handles = ["overlay.send"]
+
+    async def handle(self, event) -> None:
+        payload = getattr(event, "payload", {}) or {}
+        if not payload:
+            logger.debug("[overlay_send] empty payload")
+            return
+
+        # Ensure relay flag so the overlay sink forwards the event and the
+        # overlay toast plugin displays a notification.
+        new_payload = dict(payload)
+        new_payload.setdefault("_relay", True)
+
+        await self.ctx.bus.publish(
+            Event(
+                type="overlay.toast",
+                payload=new_payload,
+                priority=getattr(event, "priority", 5),
+                source=getattr(event, "source", "agent"),
+            )
+        )

--- a/tests/test_overlay_send_plugin.py
+++ b/tests/test_overlay_send_plugin.py
@@ -1,0 +1,25 @@
+import asyncio
+from types import SimpleNamespace
+
+from agent.plugins.overlay_send_plugin import OverlaySendPlugin
+from agent.schemas import Event
+
+
+def test_overlay_send_plugin_republishes(monkeypatch):
+    published = []
+
+    class DummyBus:
+        async def publish(self, e):
+            published.append(e)
+
+    ctx = SimpleNamespace(bus=DummyBus())
+    plugin = OverlaySendPlugin(ctx)
+
+    asyncio.run(plugin.handle(Event(type="overlay.send", payload={"title": "T", "text": "hi"})))
+
+    assert len(published) == 1
+    e = published[0]
+    assert e.type == "overlay.toast"
+    assert e.payload["title"] == "T"
+    assert e.payload["text"] == "hi"
+    assert e.payload["_relay"] is True


### PR DESCRIPTION
## Summary
- add overlay send plugin to republish overlay.send events as relayed overlay.toast messages
- document new plugin in Agent memory
- test that overlay.send events are converted for overlay relays

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement torch>=2.1.0)*
- `apt-get update` *(fails: repository InRelease 403 Forbidden)*
- `pytest -q` *(fails: PortAudio library not found; libGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bccd5144b4833397a37be9b7b4e76b