### PR TITLE
feat: relay overlay messages and route toast

### DIFF
--- a/Agent memory for working.txt
+++ b/Agent memory for working.txt
@@ -101,3 +101,6 @@
 - overlay_sink now forwards relayed overlay.toast events from agent.server._toast_handler so server toasts appear once in the overlay; cross-module deduplication still pending.
 - Overlay sink now relays server toast messages while a new overlay toast plugin shows relayed events as Windows notifications.
 - Added overlay send plugin so overlay.send events republish as relayed overlay.toast messages, allowing Luna Overlay to display messages while overlay toasts show Windows notifications; cross-module deduplication still pending.
+
+- Overlay send plugin now republishes overlay.send as both overlay.toast and overlay.message events so messages appear in the overlay feed while toasts trigger Windows notifications; cross-module deduplication still pending.
+- Overlay sink now sends overlay.toast to the toast endpoint and other overlay.* events to the main event feed; further overlay/message routing features remain.

--- a/agent/plugins/overlay_send_plugin.py
+++ b/agent/plugins/overlay_send_plugin.py
@@ -1,18 +1,7 @@
-from __future__ import annotations
-
-"""
-Overlay send plugin v2: relay to BOTH toast and overlay message feed.
-
-- Listens for `overlay.send`.
-- Re-emits:
-  1) `overlay.toast` with `_relay=True` for Windows toast
-  2) `overlay.message` with `_relay=True` for Luna Overlay message feed
-"""
-
-import time
-from loguru import logger
 from agent.schemas import Event
 from . import BasePlugin
+from loguru import logger
+import time
 
 
 class OverlaySendPlugin(BasePlugin):
@@ -20,7 +9,6 @@ class OverlaySendPlugin(BasePlugin):
     handles = ["overlay.send"]
 
     def _normalize(self, payload: dict) -> dict:
-        """Normalize fields so both toast and overlay message have what they need."""
         p = dict(payload or {})
         p.setdefault("_relay", True)
         p.setdefault("title", p.get("title", "") or p.get("heading", "") or "")
@@ -38,24 +26,18 @@ class OverlaySendPlugin(BasePlugin):
 
         norm = self._normalize(payload)
 
-        # 1) 윈도우 토스트용 (sink가 /overlay/event 로 보냄)
-        await self.ctx.bus.publish(
-            Event(
-                type="overlay.toast",
-                payload=norm,
-                priority=getattr(event, "priority", 5),
-                source=getattr(event, "source", "agent"),
-            )
-        )
+        # 1) 윈도우 토스트 라인
+        await self.ctx.bus.publish(Event(
+            type="overlay.toast",
+            payload=norm,
+            priority=getattr(event, "priority", 5),
+            source=getattr(event, "source", "agent"),
+        ))
 
-        # 2) 오버레이 메시지 피드용 (sink가 /event 로 보냄)
-        await self.ctx.bus.publish(
-            Event(
-                type="overlay.message",
-                payload=norm,
-                priority=getattr(event, "priority", 5),
-                source=getattr(event, "source", "agent"),
-            )
-        )
-
-        logger.debug("[overlay_send] relayed to overlay.toast and overlay.message")
+        # 2) 오버레이 메시지 피드 라인
+        await self.ctx.bus.publish(Event(
+            type="overlay.message",
+            payload=norm,
+            priority=getattr(event, "priority", 5),
+            source=getattr(event, "source", "agent"),
+        ))

--- a/agent/plugins/overlay_sink.py
+++ b/agent/plugins/overlay_sink.py
@@ -295,12 +295,10 @@ class EnhancedOverlaySink(BasePlugin):
             if event_type == "overlay.toast":
                 target_url = OVERLAY_TOAST_URL
             elif event_type.startswith("overlay."):
-                # overlay.message, overlay.whatever 등은 메시지 피드로
-                target_url = OVERLAY_EVENT_URL
+                target_url = OVERLAY_EVENT_URL  # overlay.message 등은 메시지 피드로
             else:
                 target_url = OVERLAY_EVENT_URL
-            if event_type == "overlay.toast" and not payload.get("_relay"):
-                return
+
             success = await self._post_with_retry(target_url, formatted_event)
             
             if success:

--- a/tests/test_overlay_send_plugin.py
+++ b/tests/test_overlay_send_plugin.py
@@ -17,9 +17,11 @@ def test_overlay_send_plugin_republishes(monkeypatch):
 
     asyncio.run(plugin.handle(Event(type="overlay.send", payload={"title": "T", "text": "hi"})))
 
-    assert len(published) == 1
-    e = published[0]
-    assert e.type == "overlay.toast"
-    assert e.payload["title"] == "T"
-    assert e.payload["text"] == "hi"
-    assert e.payload["_relay"] is True
+    assert len(published) == 2
+    toast, message = published
+    assert toast.type == "overlay.toast"
+    assert message.type == "overlay.message"
+    for e in (toast, message):
+        assert e.payload["title"] == "T"
+        assert e.payload["text"] == "hi"
+        assert e.payload["_relay"] is True

--- a/tests/test_overlay_sink.py
+++ b/tests/test_overlay_sink.py
@@ -1,5 +1,9 @@
 import asyncio
-from agent.plugins.overlay_sink import EnhancedOverlaySink
+from agent.plugins.overlay_sink import (
+    EnhancedOverlaySink,
+    OVERLAY_TOAST_URL,
+    OVERLAY_EVENT_URL,
+)
 from agent.schemas import Event
 
 
@@ -58,7 +62,7 @@ def test_ocr_event_forwarded(monkeypatch):
     assert inner['text'] == 'generic'
 
 
-def test_overlay_toast_relay(monkeypatch):
+def test_overlay_routing(monkeypatch):
     sink = EnhancedOverlaySink()
     captured = []
 
@@ -73,9 +77,15 @@ def test_overlay_toast_relay(monkeypatch):
     asyncio.run(sink.handle(event))
     assert captured == []
 
-    # relayed toast should be forwarded to overlay
+    # relayed toast should go to toast URL
     event2 = Event(type="overlay.toast", payload={"title": "T", "text": "hi", "_relay": True})
     asyncio.run(sink.handle(event2))
 
-    assert captured and captured[0][1]["type"] == "overlay.toast"
-    assert captured[0][1]["payload"]["title"] == "T"
+    # overlay.message should go to event URL
+    event3 = Event(type="overlay.message", payload={"title": "M", "text": "hey", "_relay": True})
+    asyncio.run(sink.handle(event3))
+
+    assert captured[0][0] == OVERLAY_TOAST_URL
+    assert captured[0][1]["type"] == "overlay.toast"
+    assert captured[1][0] == OVERLAY_EVENT_URL
+    assert captured[1][1]["type"] == "overlay.message"


### PR DESCRIPTION
## Summary
- relay overlay.send events to both overlay.toast and overlay.message
- route overlay.toast to the toast endpoint while other overlay.* events use the normal feed
- document new overlay behaviour in project memory and tests

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement torch>=2.1.0)*
- `pytest -q` *(fails: PortAudio library not found; libGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd2452b908333b9d5d379c110e58c